### PR TITLE
Extending the syntax of GRIN: HPT

### DIFF
--- a/grin/grin.cabal
+++ b/grin/grin.cabal
@@ -256,6 +256,7 @@ test-suite grin-test
                      , inline-c
 
   other-modules:
+                     ExtendedSyntax.LintSpec
                      ExtendedSyntax.ParserSpec
                      Transformations.ExtendedSyntax.ConversionSpec
                      Transformations.Simplifying.RegisterIntroductionSpec

--- a/grin/grin.cabal
+++ b/grin/grin.cabal
@@ -112,6 +112,7 @@ library
     Test.Test
     Test.Util
     Test.ExtendedSyntax.Assertions
+    Test.ExtendedSyntax.Util
     Test.ExtendedSyntax.Old.Grammar
     Test.ExtendedSyntax.Old.Test
     Transformations.BindNormalisation

--- a/grin/grin.cabal
+++ b/grin/grin.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src
   default-extensions:  OverloadedStrings
   exposed-modules:
+    AbstractInterpretation.ExtendedSyntax.IR
     AbstractInterpretation.ExtendedSyntax.HeapPointsTo.CodeGenBase
     AbstractInterpretation.ExtendedSyntax.HeapPointsTo.CodeGen
     AbstractInterpretation.ExtendedSyntax.HeapPointsTo.Pretty

--- a/grin/grin.cabal
+++ b/grin/grin.cabal
@@ -81,11 +81,13 @@ library
     Grin.ExtendedSyntax.SyntaxDefs
     Grin.ExtendedSyntax.Grin
     Grin.ExtendedSyntax.EffectMap
+    Grin.ExtendedSyntax.Lint
     Grin.ExtendedSyntax.Parse
     Grin.ExtendedSyntax.Parse.AST
     Grin.ExtendedSyntax.Parse.Basic
     Grin.ExtendedSyntax.Parse.TypeEnv
     Grin.ExtendedSyntax.Pretty
+    Grin.ExtendedSyntax.PrimOpsPrelude
     Grin.ExtendedSyntax.TH
     Grin.ExtendedSyntax.TypeEnv
     Grin.ExtendedSyntax.TypeEnvDefs
@@ -121,6 +123,7 @@ library
     Transformations.UnitPropagation
     Transformations.Util
     Transformations.ExtendedSyntax.Conversion
+    Transformations.ExtendedSyntax.Util
     Transformations.Optimising.ArityRaising
     Transformations.Optimising.CaseCopyPropagation
     Transformations.Optimising.CaseHoisting

--- a/grin/grin.cabal
+++ b/grin/grin.cabal
@@ -18,6 +18,12 @@ library
   default-extensions:  OverloadedStrings
   exposed-modules:
     AbstractInterpretation.ExtendedSyntax.IR
+    AbstractInterpretation.ExtendedSyntax.PrettyIR
+    AbstractInterpretation.ExtendedSyntax.BinaryIR
+    AbstractInterpretation.ExtendedSyntax.BinaryResult
+    AbstractInterpretation.ExtendedSyntax.ReduceCpp
+    AbstractInterpretation.ExtendedSyntax.Reduce
+    AbstractInterpretation.ExtendedSyntax.Util
     AbstractInterpretation.ExtendedSyntax.HeapPointsTo.CodeGenBase
     AbstractInterpretation.ExtendedSyntax.HeapPointsTo.CodeGen
     AbstractInterpretation.ExtendedSyntax.HeapPointsTo.Pretty
@@ -287,6 +293,7 @@ test-suite grin-test
                      ParserSpec
                      PrimOpsSpec
                      NametableSpec
+                     AbstractInterpretation.ExtendedSyntax.HptSpec
                      AbstractInterpretation.HptSpec
                      AbstractInterpretation.LiveVariableSpec
                      AbstractInterpretation.EffectTrackingSpec

--- a/grin/grin.cabal
+++ b/grin/grin.cabal
@@ -17,6 +17,10 @@ library
   hs-source-dirs:      src
   default-extensions:  OverloadedStrings
   exposed-modules:
+    AbstractInterpretation.ExtendedSyntax.HeapPointsTo.CodeGenBase
+    AbstractInterpretation.ExtendedSyntax.HeapPointsTo.CodeGen
+    AbstractInterpretation.ExtendedSyntax.HeapPointsTo.Pretty
+    AbstractInterpretation.ExtendedSyntax.HeapPointsTo.Result
     AbstractInterpretation.CreatedBy.Result
     AbstractInterpretation.CreatedBy.Readback
     AbstractInterpretation.CreatedBy.Util

--- a/grin/grin.cabal
+++ b/grin/grin.cabal
@@ -89,6 +89,7 @@ library
     Grin.ExtendedSyntax.Pretty
     Grin.ExtendedSyntax.PrimOpsPrelude
     Grin.ExtendedSyntax.TH
+    Grin.ExtendedSyntax.TypeCheck
     Grin.ExtendedSyntax.TypeEnv
     Grin.ExtendedSyntax.TypeEnvDefs
     Pipeline.Eval

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/BinaryIR.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/BinaryIR.hs
@@ -1,0 +1,251 @@
+{-# LANGUAGE LambdaCase, RecordWildCards, Strict #-}
+module AbstractInterpretation.ExtendedSyntax.BinaryIR (encodeAbstractProgram) where
+
+import Control.Monad.State
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Map (Map)
+import qualified Data.Map as Map
+import qualified Data.ByteString.Lazy as LBS
+import Data.ByteString.Builder
+
+import AbstractInterpretation.ExtendedSyntax.IR
+
+data Env
+  = Env
+  { envTagMap         :: Map (Set Tag) Int32
+  , envBlockCount     :: !Int
+  , envBuilder        :: !Builder
+  , envBuilderMap     :: Map Int (Int, Builder) -- block size, data
+  , envInstCount      :: !Int
+  }
+
+emptyEnv = Env
+  { envTagMap         = mempty
+  , envBlockCount     = 0
+  , envBuilder        = mempty
+  , envBuilderMap     = mempty
+  , envInstCount      = 0
+  }
+
+type W = State Env
+
+emit :: Builder -> W ()
+emit b = modify' $ \env@Env{..} -> env {envBuilder = envBuilder <> b}
+
+writeI32 :: Int32 -> W ()
+writeI32 i = emit $ int32LE i
+
+writeW32 :: Word32 -> W ()
+writeW32 w = emit $ word32LE w
+
+writeReg :: Reg -> W ()
+writeReg (Reg r) = writeW32 r
+
+writeMem :: Mem -> W ()
+writeMem (Mem m) = writeW32 m
+
+writeTagSet :: Set Tag -> W ()
+writeTagSet s = do
+  tm <- gets envTagMap
+  let size = fromIntegral $ Map.size tm
+  case Map.lookup s tm of
+    Just idx -> writeI32 idx
+    Nothing -> do
+      modify' $ \env@Env{..} -> env {envTagMap = Map.insert s size envTagMap}
+      writeI32 size
+
+writeBlock :: [Instruction] -> W ()
+writeBlock il = do
+  let size = length il
+  blockIndex <- gets envBlockCount
+  modify' $ \env@Env{..} -> env {envInstCount = envInstCount + size, envBlockCount = succ blockIndex}
+  writeI32 $ fromIntegral blockIndex
+  savedBuilder <- gets envBuilder
+  modify' $ \env@Env{..} -> env {envBuilder = mempty}
+  mapM_ writeInstruction il
+  blockBuilder <- gets envBuilder
+  modify' $ \env@Env{..} -> env {envBuilder = savedBuilder, envBuilderMap = Map.insert blockIndex (size, blockBuilder) envBuilderMap}
+
+-----------------------------------
+
+writeRange :: Range -> W ()
+writeRange Range{..} = do
+  writeI32 from
+  writeI32 to
+
+writeType :: Int32 -> W ()
+writeType = writeI32
+
+writeTag :: Tag -> W ()
+writeTag (Tag w) = writeW32 w
+
+writePredicate :: Predicate -> W ()
+writePredicate = \case
+  TagIn s -> do
+    writeType 100
+    writeTagSet s
+  TagNotIn s -> do
+    writeType 101
+    writeTagSet s
+  ValueIn r -> do
+    writeType 102
+    writeRange r
+  ValueNotIn r -> do
+    writeType 103
+    writeRange r
+
+writeCondition :: Condition -> W ()
+writeCondition = \case
+  NodeTypeExists t -> do
+    writeType 200
+    writeTag t
+  SimpleTypeExists st -> do
+    writeType 201
+    writeI32 st
+  AnyNotIn s -> do
+    writeType 202
+    writeTagSet s
+  Any p -> do
+    writeType 203
+    writePredicate p
+
+writeSelector :: Selector -> W ()
+writeSelector = \case
+  NodeItem t i -> do
+    writeType 300
+    writeTag t
+    writeI32 $ fromIntegral i
+  ConditionAsSelector c -> do
+    writeType 301
+    writeCondition c
+  AllFields -> do
+    writeType 302
+
+writeConstant :: Constant -> W ()
+writeConstant = \case
+  CSimpleType st -> do
+    writeType 400
+    writeI32 st
+  CHeapLocation m -> do
+    writeType 401
+    writeMem m
+  CNodeType t a -> do
+    writeType 402
+    writeTag t
+    writeI32 $ fromIntegral a
+  CNodeItem t i v -> do
+    writeType 403
+    writeTag t
+    writeI32 $ fromIntegral i
+    writeI32 v
+
+writeInstruction :: Instruction -> W ()
+writeInstruction = \case
+  If {..} -> do
+    writeType 500
+    writeCondition condition
+    writeReg srcReg
+    writeBlock instructions
+  Project {..} -> do
+    writeType 501
+    writeSelector srcSelector
+    writeReg srcReg
+    writeReg dstReg
+  Extend {..} -> do
+    writeType 502
+    writeReg srcReg
+    writeSelector dstSelector
+    writeReg dstReg
+  Move {..} -> do
+    writeType 503
+    writeReg srcReg
+    writeReg dstReg
+  RestrictedMove {..} -> do
+    writeType 504
+    writeReg srcReg
+    writeReg dstReg
+  ConditionalMove {..} -> do
+    writeType 505
+    writeReg srcReg
+    writePredicate predicate
+    writeReg dstReg
+  Fetch {..} -> do
+    writeType 506
+    writeReg addressReg
+    writeReg dstReg
+  Store {..} -> do
+    writeType 507
+    writeReg srcReg
+    writeMem address
+  Update {..} -> do
+    writeType 508
+    writeReg srcReg
+    writeReg addressReg
+  RestrictedUpdate {..} -> do
+    writeType 509
+    writeReg srcReg
+    writeReg addressReg
+  ConditionalUpdate {..} -> do
+    writeType 510
+    writeReg srcReg
+    writePredicate predicate
+    writeReg addressReg
+  Set {..} -> do
+    writeType 511
+    writeReg dstReg
+    writeConstant constant
+
+{-
+  memory count    i32
+  register count  i32
+  start block id  i32
+  cmd count       i32
+  cmds ...
+  block count     i32
+  blocks (ranges) ...
+  intset count  i32
+    set size      i32
+    set elems ... [i32]
+-}
+
+writeBlockItem :: Int32 -> Int -> W Int32
+writeBlockItem offset size = do
+  let nextOffset = offset + fromIntegral size
+  writeI32 $ offset
+  writeI32 $ nextOffset
+  pure nextOffset
+
+encodeAbstractProgram :: AbstractProgram -> LBS.ByteString
+encodeAbstractProgram AbstractProgram {..} = toLazyByteString (envBuilder env) where
+  env = flip execState emptyEnv $ do
+    writeW32 _absMemoryCounter
+    writeW32 _absRegisterCounter
+
+    -- start block id
+    writeBlock _absInstructions
+
+    -- commands
+    cmdCount <- gets envInstCount
+    writeI32 $ fromIntegral cmdCount
+    (blockSizes, blocks) <- gets $ unzip . Map.elems . envBuilderMap
+    mapM emit blocks
+
+    -- bocks
+    blkCount <- gets envBlockCount
+    writeI32 $ fromIntegral blkCount
+    foldM_ writeBlockItem 0 blockSizes
+
+    -- intsets
+    {-
+    setCount <- gets envTagSetCount
+    writeI32 $ fromIntegral setCount
+    sets <- gets envTagSets
+    -}
+    tagMap <- gets envTagMap
+    writeI32 $ fromIntegral $ Map.size tagMap
+    let sets = Map.elems $ Map.fromList [(i, s) | (s, i) <- Map.toList tagMap]
+
+    forM_ sets $ \s -> do
+      writeI32 $ fromIntegral $ Set.size s
+      forM_ (Set.toList s) (\(Tag t) -> writeI32 $ fromIntegral t)

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/BinaryResult.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/BinaryResult.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE LambdaCase, RecordWildCards #-}
+module AbstractInterpretation.ExtendedSyntax.BinaryResult where
+
+import Data.Int
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import Data.Vector (Vector)
+import qualified Data.Vector as V
+import Data.Binary.Get
+import qualified Data.ByteString.Lazy as LBS
+
+import Control.Monad
+
+import AbstractInterpretation.ExtendedSyntax.IR
+import AbstractInterpretation.ExtendedSyntax.Reduce (NodeSet(..), Value(..), ComputerState(..), AbstractInterpretationResult(..))
+
+checkTag :: Int32 -> String -> Get ()
+checkTag tag msg = do
+  i <- getInt32le
+  when (i /= tag) $ fail msg
+
+readTag :: Get Tag
+readTag = Tag <$> getWord32le
+
+readIntSet :: Get (Set Int32)
+readIntSet = do
+  checkTag 1000 "int set expected"
+  size <- fromIntegral <$> getInt32le
+  Set.fromList <$> replicateM size getInt32le
+
+readNodeItem :: Get (Vector (Set Int32))
+readNodeItem = do
+  checkTag 1001 "node item expected"
+  size <- fromIntegral <$> getInt32le
+  V.fromList <$> replicateM size readIntSet
+
+readNodeSet :: Get NodeSet
+readNodeSet = do
+  checkTag 1002 "node set expected"
+  size <- fromIntegral <$> getInt32le
+  NodeSet . Map.fromList <$> replicateM size ((,) <$> readTag <*> readNodeItem)
+
+readValue :: Get Value
+readValue = do
+  checkTag 1003 "value expected"
+  Value <$> readIntSet <*> readNodeSet
+
+readAbstractInterpretationResult :: Get AbstractInterpretationResult
+readAbstractInterpretationResult = do
+  iterCount <- fromIntegral <$> getInt32le
+  memCount <- fromIntegral <$> getInt32le
+  regCount <- fromIntegral <$> getInt32le
+  mem <- V.fromList <$> replicateM memCount readNodeSet
+  reg <- V.fromList <$> replicateM regCount readValue
+  pure $ AbsIntResult
+    { _airComp  = ComputerState {_memory = mem, _register = reg}
+    , _airIter  = iterCount
+    }
+
+
+loadAbstractInterpretationResult :: String -> IO AbstractInterpretationResult
+loadAbstractInterpretationResult fname = do
+  runGet readAbstractInterpretationResult <$> LBS.readFile fname

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/CodeGen.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/CodeGen.hs
@@ -194,6 +194,9 @@ codeGenM = cata folder where
           AsPat varName Lit{} -> do
             addReg varName r
             pure () -- TODO: is this ok? or error?
+          AsPat v1 (Var v2) -> do
+            addReg v1 r
+            addReg v2 r
           AsPat varName (ConstTagNode tag args) -> do
             addReg varName r
             irTag <- getTag tag
@@ -202,8 +205,8 @@ codeGenM = cata folder where
               addReg name argReg
               pure [IR.Project {srcSelector = IR.NodeItem irTag idx, srcReg = r, dstReg = argReg}]
             -- QUESTION: In HPTProgram the instructions are in reverse order, here they are in regular order, isn't this inconsistent?
-            -- A: each cpat argument has zero or one instruction
-            --    the order of cpat binding evaluation does not matter because they does not depend on each other
+            -- ANSWER: Each cpat argument has zero or one instruction.
+            --    The order of cpat binding evaluation does not matter because they don't depend on each other.
             emit IR.If
               { condition     = IR.NodeTypeExists irTag
               , srcReg        = r

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/CodeGen.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/CodeGen.hs
@@ -213,7 +213,7 @@ codeGenM = cata folder where
       rightExp
 
     ECaseF scrut alts_ -> do
-      scrutReg <- newReg
+      scrutReg <- getReg scrut
       addReg scrut scrutReg
       caseResultReg <- newReg
 

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/CodeGen.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/CodeGen.hs
@@ -14,11 +14,11 @@ import Data.Functor.Foldable as Foldable
 
 import Lens.Micro.Platform
 
-import Grin.Grin
-import Grin.TypeEnv
-import qualified AbstractInterpretation.IR as IR
-import AbstractInterpretation.IR (Instruction(..), AbstractProgram(..), AbstractMapping(..))
-import AbstractInterpretation.HeapPointsTo.CodeGenBase
+import Grin.ExtendedSyntax.Grin
+import Grin.ExtendedSyntax.TypeEnv
+import qualified AbstractInterpretation.ExtendedSyntax.IR as IR
+import AbstractInterpretation.ExtendedSyntax.IR (Instruction(..), AbstractProgram(..), AbstractMapping(..))
+import AbstractInterpretation.ExtendedSyntax.HeapPointsTo.CodeGenBase
 
 codeGen :: Program -> (AbstractProgram, HPTMapping)
 codeGen prg@(Program exts defs) = evalState (codeGenM prg >> mkAbstractProgramM) emptyCGState

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/CodeGen.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/CodeGen.hs
@@ -1,0 +1,456 @@
+{-# LANGUAGE LambdaCase, RecordWildCards, TupleSections, TemplateHaskell, OverloadedStrings #-}
+module AbstractInterpretation.ExtendedSyntax.HeapPointsTo.CodeGen where
+
+import Control.Monad.State
+
+import Data.Set (Set)
+import Data.Map (Map)
+import Data.Vector (Vector)
+
+import qualified Data.Set as Set
+import qualified Data.Map as Map
+import qualified Data.Vector as Vec
+import Data.Functor.Foldable as Foldable
+
+import Lens.Micro.Platform
+
+import Grin.Grin
+import Grin.TypeEnv
+import qualified AbstractInterpretation.IR as IR
+import AbstractInterpretation.IR (Instruction(..), AbstractProgram(..), AbstractMapping(..))
+import AbstractInterpretation.HeapPointsTo.CodeGenBase
+
+codeGen :: Program -> (AbstractProgram, HPTMapping)
+codeGen prg@(Program exts defs) = evalState (codeGenM prg >> mkAbstractProgramM) emptyCGState
+codeGen _ = error "Program expected"
+
+mkAbstractProgramM :: CG (AbstractProgram, HPTMapping)
+mkAbstractProgramM = do
+  CGState{..} <- get
+  let prg = AbstractProgram
+        { _absMemoryCounter   = _sMemoryCounter
+        , _absRegisterCounter = _sRegisterCounter
+        , _absInstructions    = _sInstructions
+        }
+  let mpg = AbstractMapping
+        { _absRegisterMap     = _sRegisterMap
+        , _absFunctionArgMap  = _sFunctionArgMap
+        , _absTagMap          = _sTagMap
+        }
+  pure (prg, mpg)
+
+unitType :: IR.SimpleType
+unitType = codegenSimpleType T_Unit
+{-
+type ValueMapping = (Map Typeable Int, Int)
+type MappingM = State ValueMapping
+
+class (Typeable a, Enum a, Bounded a) => IntValue a where
+  toInt   :: Monad m => a -> m Int
+  fromInt :: Monad m => Int -> m a
+-}
+codegenSimpleType :: SimpleType -> IR.SimpleType
+codegenSimpleType = \case
+  T_Unit    -> -1
+  T_Int64   -> -2
+  T_Word64  -> -3
+  T_Float   -> -4
+  T_Bool    -> -5
+  T_String  -> -6
+  T_Char    -> -7
+
+litToSimpleType :: Lit -> IR.SimpleType
+litToSimpleType = codegenSimpleType . typeOfLitST
+
+codeGenNodeTypeHPT :: Tag -> Vector SimpleType -> CG IR.Reg
+codeGenNodeTypeHPT tag ts = do
+  let ts' = Vec.toList ts
+  r <- newReg
+  irTag <- getTag tag
+  argRegs <- mapM codeGenSimpleType ts'
+  emit IR.Set {dstReg = r, constant = IR.CNodeType irTag (length argRegs)}
+  forM_ (zip [0..] argRegs) $ \(idx, argReg) ->
+    emit IR.Extend {srcReg = argReg, dstSelector = IR.NodeItem irTag idx, dstReg = r}
+  pure r
+
+codeGenVal :: Val -> CG IR.Reg
+codeGenVal = \case
+  ConstTagNode tag vals -> do
+    r <- newReg
+    irTag <- getTag tag
+    emit IR.Set {dstReg = r, constant = IR.CNodeType irTag (length vals)}
+    forM_ (zip [0..] vals) $ \(idx, val) -> case val of
+      Var name -> do
+        valReg <- getReg name
+        emit IR.Extend
+          { srcReg      = valReg
+          , dstSelector = IR.NodeItem irTag idx
+          , dstReg      = r
+          }
+      Lit lit -> emit IR.Set {dstReg = r, constant = IR.CNodeItem irTag idx (litToSimpleType lit)}
+      Undefined (T_SimpleType t) -> do
+        tmp <- codeGenSimpleType t
+        emit IR.Extend
+          { srcReg      = tmp
+          , dstSelector = IR.NodeItem irTag idx
+          , dstReg      = r
+          }
+      _ -> error $ "illegal node item value " ++ show val
+    pure r
+  Unit -> do
+    r <- newReg
+    emit IR.Set {dstReg = r, constant = IR.CSimpleType (-1)}
+    pure r
+  Lit lit -> do
+    r <- newReg
+    emit IR.Set
+      { dstReg    = r
+      , constant  = IR.CSimpleType (litToSimpleType lit)
+      }
+    pure r
+  Var name -> getReg name
+  Undefined t -> codeGenType codeGenSimpleType (codeGenNodeSetWith codeGenNodeTypeHPT) t
+  val -> error $ "unsupported value " ++ show val
+
+typeTag :: Name -> Tag
+typeTag n = Tag F n -- FIXME: this is a hack
+
+projectType :: IR.Reg -> Ty -> CG [(Name, IR.Reg)]
+projectType argReg = \case
+  TySimple{}      -> pure []
+  TyVar name      -> pure [(name, argReg)]
+  TyCon name args -> do
+    r <- newReg
+    emit IR.Fetch {addressReg = argReg, dstReg = r}
+    irTag <- getTag $ typeTag name
+    fmap concat $ forM (zip [0..] args) $ \(idx, ty) -> do
+      r1 <- newReg
+      emit IR.Project {srcSelector = IR.NodeItem irTag idx, srcReg = r, dstReg = r1}
+      projectType r1 ty
+
+constructType :: [(Name, IR.Reg)] -> Ty -> CG IR.Reg
+constructType argMap = \case
+  TySimple simpleType -> do
+    r <- newReg
+    emit IR.Set {dstReg = r, constant = IR.CSimpleType (codegenSimpleType simpleType)}
+    pure r
+  TyVar name -> do
+    r <- newReg
+    mapM_ emit [IR.Move {srcReg = q, dstReg = r} | (n,q) <- argMap, n == name]
+    pure r
+  TyCon name args -> do
+    -- construct type node
+    valReg <- newReg
+    irTag <- getTag $ typeTag name
+    emit IR.Set {dstReg = valReg, constant = IR.CNodeType irTag (length args)}
+    -- fill type node componets
+    forM_ (zip [0..] args) $ \(idx, ty) -> do
+      q <- constructType argMap ty
+      emit IR.Extend
+        { srcReg      = q
+        , dstSelector = IR.NodeItem irTag idx
+        , dstReg      = valReg
+        }
+    -- store type node on abstract heap
+    loc <- newMem
+    r <- newReg
+    emit IR.Store {srcReg = valReg, address = loc}
+    emit IR.Set {dstReg = r, constant = IR.CHeapLocation loc}
+    pure r
+
+codeGenExternal :: External -> [Val] -> CG Result
+codeGenExternal External{..} args = do
+  valRegs <- mapM codeGenVal args
+  argMap <- concat <$> zipWithM projectType valRegs eArgsType
+  r <- constructType argMap eRetType
+  pure $ R r
+
+codeGenM :: Exp -> CG Result
+codeGenM = cata folder where
+  folder :: ExpF (CG Result) -> CG Result
+  folder = \case
+    ProgramF exts defs -> mapM_ addExternal exts >> sequence_ defs >> pure Z
+
+    DefF name args body -> do
+      instructions <- state $ \s@CGState{..} -> (_sInstructions, s {_sInstructions = []})
+      (funResultReg, funArgRegs) <- getOrAddFunRegs name $ length args
+      zipWithM_ addReg args funArgRegs
+      body >>= \case
+        Z   -> emit IR.Set {dstReg = funResultReg, constant = IR.CSimpleType unitType}
+        R r -> emit IR.Move {srcReg = r, dstReg = funResultReg}
+      -- QUESTION: why do we reverse?
+      -- A: because the list is built in reversed order (cons) and it is more efficient to reverse only once
+      modify' $ \s@CGState{..} -> s {_sInstructions = reverse _sInstructions ++ instructions}
+      pure Z
+
+    EBindF leftExp lpat rightExp -> do
+      leftExp >>= \case
+        Z -> case lpat of
+          Unit -> pure ()
+          Var name -> do
+            r <- newReg
+            emit IR.Set {dstReg = r, constant = IR.CSimpleType unitType}
+            addReg name r
+          _ -> error $ "pattern mismatch at HPT bind codegen, expected Unit got " ++ show lpat
+        R r -> case lpat of -- QUESTION: should the evaluation continue if the pattern does not match yet?
+          Unit  -> pure () -- TODO: is this ok? or error?
+          -- NOTE: I think this is okay. Could be optimised though (since we already know the result)?
+          Lit{} -> pure () -- TODO: is this ok? or error?
+          Var name -> addReg name r
+          ConstTagNode tag args -> do
+            irTag <- getTag tag
+            bindInstructions <- forM (zip [0..] args) $ \(idx, arg) -> case arg of
+              Var name -> do
+                argReg <- newReg
+                addReg name argReg
+                pure [IR.Project {srcSelector = IR.NodeItem irTag idx, srcReg = r, dstReg = argReg}]
+              Lit {} -> pure []
+              _ -> error $ "illegal node pattern component " ++ show arg
+            -- QUESTION: In HPTProgram the instructions are in reverse order, here they are in regular order, isn't this inconsistent?
+            -- A: each cpat argument has zero or one instruction
+            --    the order of cpat binding evaluation does not matter because they does not depend on each other
+            emit IR.If
+              { condition     = IR.NodeTypeExists irTag
+              , srcReg        = r
+              , instructions  = concat bindInstructions
+              }
+          _ -> error $ "unsupported lpat " ++ show lpat
+      rightExp
+
+    ECaseF val alts_ -> do
+      valReg <- codeGenVal val
+      caseResultReg <- newReg
+
+      -- save scrutinee register mapping
+      scrutRegMapping <- case val of
+        Var name -> Just . (name,) <$> getReg name
+        _ -> pure Nothing
+      {-
+        TODO:
+          - create scope monadic combinator to handle scopes
+          - set scrutinee value to the case alternative pattern value in the alternative scope
+      -}
+      alts <- sequence alts_
+
+      forM_ alts $ \(A cpat altM) -> do
+        let codeGenAlt bindM = codeGenBlock_ $ do
+              bindM
+              altM >>= \case
+                Z -> emit IR.Set {dstReg = caseResultReg, constant = IR.CSimpleType unitType}
+                R altResultReg -> emit IR.Move {srcReg = altResultReg, dstReg = caseResultReg}
+
+        case cpat of
+          NodePat tag vars -> do
+            irTag <- getTag tag
+            altInstructions <- codeGenAlt $ do
+              -- restrict scrutinee to alternative's domain
+              forM_ scrutRegMapping $ \(name, _) -> do
+                altScrutReg <- newReg
+                addReg name altScrutReg
+                -- NOTE: We just create a new empty register, and associate it with the scrutinee in this alternative. Then we annotate the register with restricted properties of the scrutinee.
+                emit IR.Project
+                  { srcSelector = IR.ConditionAsSelector $ IR.NodeTypeExists irTag
+                  , srcReg = valReg
+                  , dstReg = altScrutReg
+                  }
+
+              -- bind pattern variables
+              forM_ (zip [0..] vars) $ \(idx, name) -> do
+                  argReg <- newReg
+                  addReg name argReg
+                  emit IR.Project {srcSelector = IR.NodeItem irTag idx, srcReg = valReg, dstReg = argReg}
+            emit IR.If {condition = IR.NodeTypeExists irTag, srcReg = valReg, instructions = altInstructions}
+
+          LitPat lit -> do
+            altInstructions <- codeGenAlt $
+              -- restrict scrutinee to alternative's domain
+              forM_ scrutRegMapping $ \(name, _) -> do
+                altScrutReg <- newReg
+                addReg name altScrutReg
+                emit IR.Project
+                  { srcSelector = IR.ConditionAsSelector $ IR.SimpleTypeExists (litToSimpleType lit)
+                  , srcReg = valReg
+                  , dstReg = altScrutReg
+                  }
+            -- QUESTION: Redundant IF. Just for consistency?
+            emit IR.If {condition = IR.SimpleTypeExists (litToSimpleType lit), srcReg = valReg, instructions = altInstructions}
+
+          DefaultPat -> do
+            tags <- Set.fromList <$> sequence [getTag tag | A (NodePat tag _) _ <- alts]
+            altInstructions <- codeGenAlt $
+              -- restrict scrutinee to alternative's domain
+              forM_ scrutRegMapping $ \(name, _) -> do
+                altScrutReg <- newReg
+                addReg name altScrutReg
+                emit IR.Project
+                  { srcSelector = IR.ConditionAsSelector $ IR.AnyNotIn tags
+                  , srcReg = valReg
+                  , dstReg = altScrutReg
+                  }
+            -- QUESTION: Redundant IF. Just for consistency?
+            emit IR.If {condition = IR.AnyNotIn tags, srcReg = valReg, instructions = altInstructions}
+
+          _ -> error $ "HPT does not support the following case pattern: " ++ show cpat
+
+      -- restore scrutinee register mapping
+      maybe (pure ()) (uncurry addReg) scrutRegMapping
+
+      pure $ R caseResultReg
+
+    AltF cpat exp -> pure $ A cpat exp
+
+    SAppF name args -> getExternal name >>= \case
+      Just ext  -> do
+        res <- codeGenExternal ext args
+        let R r = res
+        -- HINT: workaround
+        -----------
+        -- copy args to definition's variables ; read function result register
+        (funResultReg, funArgRegs) <- getOrAddFunRegs name $ length args
+        valRegs <- mapM codeGenVal args
+        zipWithM_ (\src dst -> emit IR.Move {srcReg = src, dstReg = dst}) valRegs funArgRegs
+        -- old prim codegen
+        let External{..} = ext
+            isTySimple TySimple{} = True
+            isTySimple _ = False
+        emit IR.Move {srcReg = r, dstReg = funResultReg}
+        when (isTySimple eRetType && all isTySimple eArgsType) $ do
+          zipWithM_ (\argReg (TySimple argTy) -> emit IR.Set {dstReg = argReg, constant = IR.CSimpleType (codegenSimpleType argTy)}) funArgRegs eArgsType
+
+        pure res
+
+        -----------
+
+      Nothing   -> do
+        -- copy args to definition's variables ; read function result register
+        (funResultReg, funArgRegs) <- getOrAddFunRegs name $ length args
+        valRegs <- mapM codeGenVal args
+        zipWithM_ (\src dst -> emit IR.Move {srcReg = src, dstReg = dst}) valRegs funArgRegs
+        pure $ R funResultReg
+
+    SReturnF val -> R <$> codeGenVal val
+
+    SStoreF val -> do
+      loc <- newMem
+      r <- newReg
+      valReg <- codeGenVal val
+      emit IR.Store {srcReg = valReg, address = loc}
+      emit IR.Set {dstReg = r, constant = IR.CHeapLocation loc}
+      pure $ R r
+
+    SFetchIF name maybeIndex -> case maybeIndex of
+      Just {} -> error "HPT codegen does not support indexed fetch"
+      Nothing -> do
+        addressReg <- getReg name
+        r <- newReg
+        emit IR.Fetch {addressReg = addressReg, dstReg = r}
+        pure $ R r
+
+    SUpdateF name val -> do
+      addressReg <- getReg name
+      valReg <- codeGenVal val
+      emit IR.Update {srcReg = valReg, addressReg = addressReg}
+      pure Z
+
+    SBlockF exp -> exp
+
+{-
+  Unit      -1
+  Int       -2
+  Word      -3
+  Float     -4
+  Bool      -5
+  Undefined -9999
+-}
+
+{-
+ CONSTANT value building operations (from compile time constants)
+  add simple type
+  add heap location
+  add node type (tag + arity)
+  add node item (index + location or simple type)
+-}
+
+{-
+  >>= LPAT
+    (Tag b c d)               - node only check, arity check, tag check, copy node items to registers for a specific tag
+    Unit                      - specific simple type only check
+    Literal with simple type  - specific simple type only check
+    variable                  - copy to reg
+
+  case >>= LPAT ()
+  return >>= LPAT ()
+  store >>= LPAT
+  fetch >>= LPAT
+  update >>= LPAT
+
+  LPAT / VAL
+  T a - select items of specific tag
+  Unit- NOP ; optional check
+  Lit - NOP ; optional check
+  a   - copy all
+
+
+ bind COMPILE TIME CHECK:
+  VAL / LPAT
+  T a - T a   OK      (node)
+      - Unit  FAIL
+      - Lit   FAIL
+      - a     OK
+
+  Unit- T a   FAIL    (simple type)
+      - Unit  OK
+      - Lit   FAIL
+      - a     OK
+
+  Lit - T a   FAIL    (simple type)
+      - Unit  FAIL
+      - Lit   OK ; if matches
+      - a     OK
+
+  a   - T a   OK      (any)
+      - Unit  OK
+      - Lit   OK
+      - a     OK
+
+  LOC - T a   FAIL    (heap location)
+      - Unit  FAIL
+      - Lit   FAIL
+      - a     OK
+
+  compilation:
+    store (the only valid expression): store VAL >>= var
+      emits:
+        one time constant register setup for var
+        memory copy or one time setup
+        VAL validation
+    update DST VAL >>= (var | Unit)
+      VAL validation
+      DST validaton
+      var: emits one time setup for var ; fill with Unit type
+      Unit: nothing to do
+    fetch SRC >>= (var | (T a) | (t a))
+      SRC validation
+      var: CopyMemReg
+      (T a):
+
+-}
+
+{-
+ case COMPILE TIME CHECK:
+  VAL / CPAT
+  T a - T a   OK      (node)
+      - Lit   FAIL
+
+  Unit- T a   FAIL    (simple type)
+      - Lit   FAIL
+
+  Lit - T a   FAIL    (simple type)
+      - Lit   OK ; if matches
+
+  a   - T a   OK      (any)
+      - Lit   OK
+
+  LOC - T a   FAIL    (heap location)
+      - Lit   FAIL
+-}

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/CodeGenBase.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/CodeGenBase.hs
@@ -1,0 +1,198 @@
+{-# LANGUAGE LambdaCase, RecordWildCards, RankNTypes, TemplateHaskell #-}
+module AbstractInterpretation.ExtendedSyntax.HeapPointsTo.CodeGenBase where
+
+import Data.Int
+import Data.Word
+import Data.Set (Set)
+import Data.Map (Map)
+import Data.Vector (Vector)
+
+import qualified Data.Bimap as Bimap
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified Data.Vector as Vec
+
+import Control.Monad.State
+
+import Grin.Grin (Name, SimpleType(..), CPat(..), unpackName, Tag(..), External(..))
+import Grin.TypeEnvDefs
+import AbstractInterpretation.IR (Instruction(..), Reg(..), AbstractMapping)
+import qualified AbstractInterpretation.IR as IR
+
+import Lens.Micro.Platform
+
+type HPTMapping = AbstractMapping -- TODO
+
+data CGState
+  = CGState
+  { _sMemoryCounter   :: Word32
+  , _sRegisterCounter :: Word32
+  , _sInstructions    :: [Instruction]
+
+  -- mapping
+
+  , _sRegisterMap     :: Map Name Reg
+  , _sFunctionArgMap  :: Map Name (Reg, [Reg])
+  , _sTagMap          :: Bimap.Bimap Tag IR.Tag
+
+  -- internal
+
+  , _sExternalMap     :: Map Name External
+  }
+  deriving (Show)
+
+concat <$> mapM makeLenses [''CGState]
+
+emptyCGState :: CGState
+emptyCGState = CGState
+  { _sMemoryCounter   = 0
+  , _sRegisterCounter = 0
+  , _sInstructions    = []
+
+  -- mapping
+
+  , _sRegisterMap     = mempty
+  , _sFunctionArgMap  = mempty
+  , _sTagMap          = Bimap.empty
+
+  -- internal
+
+  , _sExternalMap     = mempty
+  }
+
+type CG = State CGState
+
+data Result
+  = R IR.Reg
+  | Z
+  | A CPat (CG Result)
+
+emit :: IR.Instruction -> CG ()
+emit inst = modify' $ \s@CGState{..} -> s {_sInstructions = inst : _sInstructions}
+
+addExternal :: External -> CG ()
+addExternal e = modify' $ \s@CGState{..} -> s {_sExternalMap = Map.insert (eName e) e _sExternalMap}
+
+getExternal :: Name -> CG (Maybe External)
+getExternal name = Map.lookup name <$> gets _sExternalMap
+
+-- creates regsiters for function arguments and result
+getOrAddFunRegs :: Name -> Int -> CG (IR.Reg, [IR.Reg])
+getOrAddFunRegs name arity = do
+  funMap <- gets _sFunctionArgMap
+  case Map.lookup name funMap of
+    Just x  -> pure x
+    Nothing -> do
+      resReg <- newReg
+      argRegs <- replicateM arity newReg
+      let funRegs = (resReg, argRegs)
+      modify' $ \s@CGState{..} -> s {_sFunctionArgMap = Map.insert name funRegs _sFunctionArgMap}
+      pure funRegs
+
+newReg :: CG IR.Reg
+newReg = state $ \s@CGState{..} -> (IR.Reg _sRegisterCounter, s {_sRegisterCounter = succ _sRegisterCounter})
+
+newMem :: CG IR.Mem
+newMem = state $ \s@CGState{..} -> (IR.Mem _sMemoryCounter, s {_sMemoryCounter = succ _sMemoryCounter})
+
+addReg :: Name -> IR.Reg -> CG ()
+addReg name reg = modify' $ \s@CGState{..} -> s {_sRegisterMap = Map.insert name reg _sRegisterMap}
+
+getReg :: Name -> CG IR.Reg
+getReg name = do
+  regMap <- gets _sRegisterMap
+  case Map.lookup name regMap of
+    Nothing   -> error $ "unknown variable " ++ unpackName name
+    Just reg  -> pure reg
+
+getTag :: Tag -> CG IR.Tag
+getTag tag = do
+  tagMap <- gets _sTagMap
+  case Bimap.lookup tag tagMap of
+    Just t  -> pure t
+    Nothing -> do
+      let t = IR.Tag . fromIntegral $ Bimap.size tagMap
+      modify' $ \s -> s {_sTagMap = Bimap.insert tag t tagMap}
+      pure t
+
+codeGenBlock :: CG a -> CG (a,[IR.Instruction])
+codeGenBlock genM = do
+  instructions <- state $ \s@CGState{..} -> (_sInstructions, s {_sInstructions = []})
+  ret <- genM
+  blockInstructions <- state $ \s@CGState{..} -> (reverse _sInstructions, s {_sInstructions = instructions})
+  pure (ret, blockInstructions)
+
+codeGenBlock_ :: CG a -> CG [IR.Instruction]
+codeGenBlock_ = fmap snd . codeGenBlock
+
+codeGenSimpleType :: SimpleType -> CG IR.Reg
+codeGenSimpleType = \case
+  T_Unit                -> newRegWithSimpleType (-1)
+  T_Int64               -> newRegWithSimpleType (-2)
+  T_Word64              -> newRegWithSimpleType (-3)
+  T_Float               -> newRegWithSimpleType (-4)
+  T_Bool                -> newRegWithSimpleType (-5)
+  T_String              -> newRegWithSimpleType (-6)
+  T_Char                -> newRegWithSimpleType (-7)
+  T_UnspecifiedLocation -> newRegWithSimpleType (-8)
+  T_Location locs -> do
+    r <- newReg
+    let locs' = map fromIntegral locs
+    mapM_ (`extendSimpleType` r) locs'
+    pure r
+  t -> newReg
+  where
+  -- TODO: rename simple type to something more generic,
+  newRegWithSimpleType :: IR.SimpleType -> CG IR.Reg
+  newRegWithSimpleType irTy = newReg >>= extendSimpleType irTy
+
+  -- TODO: rename simple type to something more generic,
+  extendSimpleType :: IR.SimpleType -> IR.Reg -> CG IR.Reg
+  extendSimpleType irTy r = do
+    emit IR.Set
+      { dstReg    = r
+      , constant  = IR.CSimpleType irTy
+      }
+    pure r
+
+codeGenNodeSetWith :: (Tag -> Vector SimpleType -> CG IR.Reg) -> NodeSet -> CG IR.Reg
+codeGenNodeSetWith cgNodeTy ns = do
+  let (tags, argss) = unzip . Map.toList $ ns
+  dst <- newReg
+  nodeRegs <- zipWithM cgNodeTy tags argss
+  forM_ nodeRegs $ \src -> emit IR.Move { srcReg = src, dstReg = dst }
+  pure dst
+
+-- Generate a node type from type information,
+-- but preserve the first field for tag information.
+codeGenTaggedNodeType :: Tag -> Vector SimpleType -> CG IR.Reg -- delete
+codeGenTaggedNodeType tag ts = do
+  let ts' = Vec.toList ts
+  r <- newReg
+  irTag <- getTag tag
+  argRegs <- mapM codeGenSimpleType ts'
+  emit IR.Set {dstReg = r, constant = IR.CNodeType irTag (length argRegs + 1)}
+  forM_ (zip [1..] argRegs) $ \(idx, argReg) ->
+    emit IR.Extend {srcReg = argReg, dstSelector = IR.NodeItem irTag idx, dstReg = r}
+  pure r
+
+-- FIXME: the following type signature is a bad oman ; it's not intuitive ; no-go ; refactor!
+codeGenType :: (SimpleType -> CG IR.Reg) -> (NodeSet -> CG IR.Reg) -> Type -> CG IR.Reg
+codeGenType cgSimpleTy cgNodeTy = \case
+  T_SimpleType t -> cgSimpleTy t
+  T_NodeSet   ns -> cgNodeTy ns
+
+isPointer :: IR.Predicate
+isPointer = IR.ValueIn (IR.Range 0 (maxBound :: Int32))
+
+isNotPointer :: IR.Predicate -- delete
+isNotPointer = IR.ValueIn (IR.Range (minBound :: Int32) 0)
+
+-- For simple types, copies only pointer information
+-- For nodes, copies the structure and the pointer information in the fields
+copyStructureWithPtrInfo :: IR.Reg -> IR.Reg -> IR.Instruction
+copyStructureWithPtrInfo srcReg dstReg = IR.ConditionalMove
+  { srcReg    = srcReg
+  , predicate = isPointer
+  , dstReg    = dstReg
+  }

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/CodeGenBase.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/CodeGenBase.hs
@@ -14,10 +14,10 @@ import qualified Data.Vector as Vec
 
 import Control.Monad.State
 
-import Grin.Grin (Name, SimpleType(..), CPat(..), unpackName, Tag(..), External(..))
-import Grin.TypeEnvDefs
-import AbstractInterpretation.IR (Instruction(..), Reg(..), AbstractMapping)
-import qualified AbstractInterpretation.IR as IR
+import Grin.ExtendedSyntax.Grin (Name, SimpleType(..), CPat(..), unpackName, Tag(..), External(..))
+import Grin.ExtendedSyntax.TypeEnvDefs
+import AbstractInterpretation.ExtendedSyntax.IR (Instruction(..), Reg(..), AbstractMapping)
+import qualified AbstractInterpretation.ExtendedSyntax.IR as IR
 
 import Lens.Micro.Platform
 

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/Pretty.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/Pretty.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE LambdaCase, RecordWildCards #-}
+module AbstractInterpretation.ExtendedSyntax.HeapPointsTo.Pretty where
+
+import Data.Functor.Foldable as Foldable
+import Text.PrettyPrint.ANSI.Leijen
+
+import Data.Set (Set)
+import qualified Data.Set as Set
+
+import Data.Map (Map)
+import qualified Data.Map as Map
+
+import Data.IntMap (IntMap)
+import qualified Data.IntMap as IntMap
+
+import Data.Vector (Vector)
+import qualified Data.Vector as V
+
+import Grin.Grin (Tag, Name)
+import Grin.Pretty
+import qualified AbstractInterpretation.HeapPointsTo.Result as R
+
+-- HPT Result NEW
+
+instance Pretty R.SimpleType where
+  pretty = \case
+    R.T_UnspecifiedLocation -> red $ text "#ptr"
+    R.T_Location l          -> cyan . int $ fromIntegral l
+    ty                      -> red $ text $ show ty
+
+prettyHPTNode :: (Tag, Vector (Set R.SimpleType)) -> Doc
+prettyHPTNode (tag, args) = pretty tag <> list (map pretty $ V.toList args)
+
+prettyHPTFunction :: (Name, (R.TypeSet, Vector R.TypeSet)) -> Doc
+prettyHPTFunction = prettyFunction
+
+instance Pretty R.NodeSet where
+  pretty (R.NodeSet m) = prettyBracedList (map prettyHPTNode $ Map.toList m)
+
+instance Pretty R.TypeSet where
+  pretty (R.TypeSet ty (R.NodeSet ns)) = prettyBracedList (map prettyHPTNode (Map.toList ns) ++ map pretty (Set.toList ty))
+
+instance Pretty R.HPTResult where
+  pretty R.HPTResult{..} = vsep
+    [ yellow (text "Heap") <$$> indent 4 (prettyKeyValue $ zip [(0 :: Int)..] $ V.toList _memory)
+    , yellow (text "Env") <$$> indent 4 (prettyKeyValue $ Map.toList  _register)
+    , yellow (text "Function") <$$> indent 4 (vsep $ map prettyHPTFunction $ Map.toList _function)
+    ]

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/Pretty.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/Pretty.hs
@@ -16,9 +16,9 @@ import qualified Data.IntMap as IntMap
 import Data.Vector (Vector)
 import qualified Data.Vector as V
 
-import Grin.Grin (Tag, Name)
-import Grin.Pretty
-import qualified AbstractInterpretation.HeapPointsTo.Result as R
+import Grin.ExtendedSyntax.Grin (Tag, Name)
+import Grin.ExtendedSyntax.Pretty
+import qualified AbstractInterpretation.ExtendedSyntax.HeapPointsTo.Result as R
 
 -- HPT Result NEW
 

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/Result.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/Result.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE LambdaCase, RecordWildCards, TemplateHaskell, GeneralizedNewtypeDeriving, TypeFamilies, DeriveFunctor, ViewPatterns #-}
+module AbstractInterpretation.ExtendedSyntax.HeapPointsTo.Result where
+
+import Data.Int
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Vector (Vector)
+import qualified Data.Vector as V
+import qualified Data.Bimap as Bimap
+
+import Lens.Micro.Platform
+import Lens.Micro.Extra
+
+import Grin.Grin (Name, Tag)
+import AbstractInterpretation.IR hiding (Tag, SimpleType)
+import AbstractInterpretation.Reduce (ComputerState(..))
+import qualified Grin.TypeEnv as TypeEnv
+import qualified AbstractInterpretation.IR as IR
+import qualified AbstractInterpretation.Reduce as R
+import AbstractInterpretation.HeapPointsTo.CodeGenBase (HPTMapping)
+
+type Loc = Int
+
+data SimpleType
+  = T_Int64
+  | T_Word64
+  | T_Float
+  | T_Bool
+  | T_Unit
+  | T_Location Loc
+  | T_String
+  | T_Char
+  | T_UnspecifiedLocation
+  {- NOTE: The local value can be used for any analysis-specific computation,
+           but cannot be propagated to the type checking phase.
+  -}
+  | Local HPTLocal
+  deriving (Eq, Ord, Show)
+
+data HPTLocal = UndefinedProducer
+  deriving (Eq, Ord, Show)
+
+undefinedProducer :: IR.SimpleType
+undefinedProducer = -1723
+
+fromHPTLocal :: HPTLocal -> IR.SimpleType
+fromHPTLocal UndefinedProducer = undefinedProducer
+
+toHPTLocal :: IR.SimpleType -> HPTLocal
+toHPTLocal t
+  | t == undefinedProducer = UndefinedProducer
+toHPTLocal t = error $ "IR simple type " ++ show t ++ " cannot be convert to HPTLocal"
+
+type    Node    = Vector (Set SimpleType)
+newtype NodeSet = NodeSet {_nodeTagMap :: Map Tag Node}
+  deriving (Eq, Ord, Show)
+
+data TypeSet
+  = TypeSet
+  { _simpleType :: Set SimpleType
+  , _nodeSet    :: NodeSet
+  }
+  deriving (Eq, Ord, Show)
+
+instance Semigroup  NodeSet where (<>)    = unionNodeSet
+instance Monoid     NodeSet where mempty  = NodeSet mempty
+
+instance Semigroup  TypeSet where (<>)    = unionTypeSet
+instance Monoid     TypeSet where mempty  = TypeSet mempty mempty
+
+unionNodeSet :: NodeSet -> NodeSet -> NodeSet
+unionNodeSet (NodeSet x) (NodeSet y) = NodeSet $ Map.unionWith unionNodeData x y where
+  unionNodeData a b
+    | V.length a == V.length b = V.zipWith Set.union a b
+    | otherwise = error $ "node arity mismatch " ++ show (V.length a) ++ " =/= " ++ show (V.length b)
+
+unionTypeSet :: TypeSet -> TypeSet -> TypeSet
+unionTypeSet a b = TypeSet
+  { _simpleType = Set.union (_simpleType a) (_simpleType b)
+  , _nodeSet    = unionNodeSet (_nodeSet a) (_nodeSet b)
+  }
+
+data HPTResult
+  = HPTResult
+  { _memory   :: Vector NodeSet
+  , _register :: Map Name TypeSet
+  , _function :: Map Name (TypeSet, Vector TypeSet)
+  }
+  deriving (Eq, Show)
+
+emptyHPTResult :: HPTResult
+emptyHPTResult = HPTResult mempty mempty mempty
+
+concat <$> mapM makeLenses [''NodeSet, ''TypeSet, ''HPTResult]
+
+-- Negative integers less than (-8) can represent any analysis-specific value.
+toSimpleType :: IR.SimpleType -> SimpleType
+toSimpleType = \case
+  -1 -> T_Unit
+  -2 -> T_Int64
+  -3 -> T_Word64
+  -4 -> T_Float
+  -5 -> T_Bool
+  -6 -> T_String
+  -7 -> T_Char
+  -8 -> T_UnspecifiedLocation
+  ty | ty < 0    -> Local $ toHPTLocal ty
+     | otherwise -> T_Location $ fromIntegral ty
+
+_T_Location :: Traversal' SimpleType Int
+_T_Location f (T_Location l) = T_Location <$> f l
+_T_Location _ rest           = pure rest
+
+toHPTResult :: HPTMapping -> R.ComputerState -> HPTResult
+toHPTResult a@AbstractMapping{..} c@R.ComputerState{..} = HPTResult
+  { _memory   = V.map (convertNodeSet s) _memory
+  , _register = Map.map (convertReg s) _absRegisterMap
+  , _function = Map.map (convertFunctionRegs s) _absFunctionArgMap
+  }
+  where
+    s = (a,c)
+
+convertReg :: (HPTMapping, ComputerState) -> Reg -> TypeSet
+convertReg s@(AbstractMapping{..}, R.ComputerState{..}) (Reg i) = convertValue s $ _register V.! (fromIntegral i)
+
+convertNodeSet :: (HPTMapping, ComputerState) -> R.NodeSet -> NodeSet
+convertNodeSet s@(AbstractMapping{..}, R.ComputerState{..}) (R.NodeSet a) = NodeSet $ Map.fromList [(_absTagMap Bimap.!> k, V.map convertSimpleType v) | (k,v) <- Map.toList a]
+
+convertSimpleType :: Set IR.SimpleType -> Set SimpleType
+convertSimpleType = Set.map toSimpleType
+
+convertValue :: (HPTMapping, ComputerState) -> R.Value -> TypeSet
+convertValue s@(AbstractMapping{..}, R.ComputerState{..}) (R.Value ty ns) = TypeSet (convertSimpleType ty) (convertNodeSet s ns)
+
+convertFunctionRegs :: (HPTMapping, ComputerState) -> (Reg, [Reg]) -> (TypeSet, Vector TypeSet)
+convertFunctionRegs s@(AbstractMapping{..}, R.ComputerState{..}) (Reg retReg, argRegs) = (convertValue s $ _register V.! (fromIntegral retReg), V.fromList [convertValue s $ _register V.! (fromIntegral argReg) | Reg argReg <- argRegs])

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/Result.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/HeapPointsTo/Result.hs
@@ -13,13 +13,13 @@ import qualified Data.Bimap as Bimap
 import Lens.Micro.Platform
 import Lens.Micro.Extra
 
-import Grin.Grin (Name, Tag)
-import AbstractInterpretation.IR hiding (Tag, SimpleType)
-import AbstractInterpretation.Reduce (ComputerState(..))
-import qualified Grin.TypeEnv as TypeEnv
-import qualified AbstractInterpretation.IR as IR
-import qualified AbstractInterpretation.Reduce as R
-import AbstractInterpretation.HeapPointsTo.CodeGenBase (HPTMapping)
+import Grin.ExtendedSyntax.Grin (Name, Tag)
+import AbstractInterpretation.ExtendedSyntax.IR hiding (Tag, SimpleType)
+import AbstractInterpretation.ExtendedSyntax.Reduce (ComputerState(..))
+import qualified Grin.ExtendedSyntax.TypeEnv as TypeEnv
+import qualified AbstractInterpretation.ExtendedSyntax.IR as IR
+import qualified AbstractInterpretation.ExtendedSyntax.Reduce as R
+import AbstractInterpretation.ExtendedSyntax.HeapPointsTo.CodeGenBase (HPTMapping)
 
 type Loc = Int
 

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/IR.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/IR.hs
@@ -1,0 +1,172 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE DeriveAnyClass, DeriveFunctor, TypeFamilies #-}
+{-# LANGUAGE DeriveFoldable, DeriveTraversable, PatternSynonyms #-}
+{-# LANGUAGE TemplateHaskell, StandaloneDeriving, DeriveGeneric #-}
+module AbstractInterpretation.ExtendedSyntax.IR
+ ( module AbstractInterpretation.ExtendedSyntax.IR
+ , Int32
+ , Word32
+ , Name
+ ) where
+
+import Data.Int
+import Data.Word
+
+import Data.Functor.Foldable.TH
+
+import qualified Data.Bimap as Bimap
+import qualified Data.Map as Map
+import Data.Set (Set)
+
+import Lens.Micro.Platform
+
+import qualified Grin.ExtendedSyntax.Grin as Grin
+import Grin.ExtendedSyntax.Grin (Name)
+import GHC.Generics (Generic)
+import Control.DeepSeq
+
+newtype Reg = Reg Word32 deriving (Eq, Ord, Show)
+newtype Mem = Mem Word32 deriving (Eq, Ord, Show)
+
+data Selector
+  = NodeItem              Tag Int   -- node item index
+  | ConditionAsSelector   Condition
+  | AllFields
+  | EveryNthField         Int
+  deriving (Eq, Ord, Show)
+
+newtype Tag = Tag Word32 deriving (Eq, Ord, Show, Generic, NFData)
+
+type SimpleType = Int32 -- TODO: rename to a generic name; should not be related to a specific domain
+
+data Condition
+  = NodeTypeExists    Tag
+  | SimpleTypeExists  SimpleType
+  | AnyNotIn          (Set Tag)
+  -- A field satisfies a predicate iff at least one of its possible values
+  -- satisfy that predicate.
+  -- NOTE: "non-deterministic" selector for Any?
+  | Any               Predicate
+  deriving (Eq, Ord, Show)
+
+data Predicate
+  = TagIn    (Set Tag)
+  | TagNotIn (Set Tag)
+  | ValueIn    Range
+  | ValueNotIn Range
+  deriving (Eq, Ord, Show)
+
+-- inclusive lower, exclusive upper bound
+data Range = Range { from :: Int32
+                   , to   :: Int32
+                   }
+  deriving (Eq, Ord, Show)
+
+-- TODO: error checking + validation ; DECISION: catch syntactical error at compile time ; the analyis will not be restrictive ; there will not be runtime checks
+
+data Instruction
+  = If
+    { condition     :: Condition
+    , srcReg        :: Reg
+    , instructions  :: [Instruction]
+    }
+  -- | projects from the tag specific SRC's node part to DST reg simple type and location set
+  | Project
+    { srcSelector   :: Selector -- ^ the selected tag must exist
+    , srcReg        :: Reg
+    , dstReg        :: Reg
+    }
+  -- | extends DST's node part for a tag by SRC reg simple type and location set
+  | Extend
+    { srcReg      :: Reg
+    , dstSelector :: Selector -- ^ the seleced tag must exist
+    , dstReg      :: Reg
+    }
+  | Move
+    { srcReg      :: Reg
+    , dstReg      :: Reg
+    }
+  -- TODO: new, more general Move
+  -- NOTE: same as Move, but only considers tags already present in dstReg
+  --       (basically a Move but only for the common tags)
+  | RestrictedMove
+    { srcReg      :: Reg
+    , dstReg      :: Reg
+    }
+  -- Moves all tags, but only those values that satisfy a given predicate.
+  | ConditionalMove
+    { srcReg      :: Reg
+    , predicate   :: Predicate
+    , dstReg      :: Reg
+    }
+  -- | copy mem (node) content addressed by SRC reg location part to DST register node part
+  | Fetch
+    { addressReg  :: Reg
+    , dstReg      :: Reg
+    }
+  -- | copy the node part of the SRC reg to mem
+  | Store
+    { srcReg      :: Reg
+    , address     :: Mem
+    }
+  -- | copy the node part of the SRC reg to mem addressed by DST reg location part
+  | Update
+    { srcReg      :: Reg
+    , addressReg  :: Reg
+    }
+  -- NOTE: same as RestrictedMove, just for heap locations
+  | RestrictedUpdate
+    { srcReg      :: Reg
+    , addressReg  :: Reg
+    }
+  -- Updates the heap with all tags, but only with those values that satisfy a given predicate.
+  | ConditionalUpdate
+    { srcReg      :: Reg
+    , predicate   :: Predicate
+    , addressReg  :: Reg
+    }
+  -- | copy compile time constant to DST register (one time setup)
+  | Set
+    { dstReg      :: Reg
+    , constant    :: Constant
+    }
+  deriving (Eq, Ord, Show)
+
+data Constant
+  = CSimpleType   SimpleType
+  | CHeapLocation Mem
+  | CNodeType     Tag Int {-arity-}
+  | CNodeItem     Tag Int {-node item index-} Int32 {-simple type, location, or incase of Cby: producer-}
+  deriving (Eq, Ord, Show)
+
+makeBaseFunctor ''Instruction
+
+data AbstractProgram
+  = AbstractProgram
+  { _absMemoryCounter    :: Word32
+  , _absRegisterCounter  :: Word32
+  , _absInstructions     :: [Instruction]
+  }
+  deriving Show
+
+data AbstractMapping
+  = AbstractMapping
+  { _absRegisterMap      :: Map.Map Name Reg
+  , _absFunctionArgMap   :: Map.Map Name (Reg, [Reg])
+  , _absTagMap           :: Bimap.Bimap Grin.Tag Tag
+  }
+  deriving Show
+
+concat <$> mapM makeLenses [''AbstractProgram, ''AbstractMapping]
+
+emptyAbstractProgram = AbstractProgram
+  { _absMemoryCounter    = 0
+  , _absRegisterCounter  = 0
+  , _absInstructions     = []
+  }
+
+emptyAbstractMapping = AbstractMapping
+  { _absRegisterMap      = Map.empty
+  , _absFunctionArgMap   = Map.empty
+  , _absTagMap           = Bimap.empty
+  }

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/PrettyIR.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/PrettyIR.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE LambdaCase, RecordWildCards #-}
+module AbstractInterpretation.ExtendedSyntax.PrettyIR where
+
+import Data.Int
+import qualified Data.Bimap as Bimap
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+
+import Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
+
+import Grin.ExtendedSyntax.Pretty ()
+import Grin.ExtendedSyntax.Grin (Name, unpackName)
+import qualified Grin.ExtendedSyntax.Grin as Grin
+import AbstractInterpretation.ExtendedSyntax.IR
+
+data IRMap
+  = IRMap
+  { irmRegisterMap  :: Map.Map Reg (Set.Set Name)
+  , irmTagMap       :: Bimap.Bimap Grin.Tag Tag
+  }
+
+printHptIr :: [Instruction] -> IO ()
+printHptIr = putDoc . pretty
+
+keyword :: String -> Doc
+keyword = yellow . text
+
+{-
+  show
+    done - tag name
+    done - register name
+    done - simple type
+    function argument
+    function return type
+
+  custom printer
+    done - Tag
+    done - Reg
+    done - Instruction
+    done - Selector
+    done - Condition
+    done - Constant
+-}
+
+instance Pretty Instruction where
+  pretty = prettyInstruction Nothing
+
+instance Pretty Reg where
+  pretty = prettyReg Nothing
+
+instance Pretty Mem where
+  pretty (Mem a) = cyan $ text "$" <> (integer $ fromIntegral a)
+
+instance Pretty Tag where
+  pretty = prettyTag Nothing
+
+instance Pretty Selector where
+  pretty = prettySelector Nothing
+
+instance Pretty Condition where
+  pretty = prettyCondition Nothing
+
+instance Pretty Constant where
+  pretty = prettyConstant Nothing
+
+instance Pretty Predicate where
+  pretty = flip (prettyPredicate Nothing) False
+
+instance Pretty Range where
+  pretty (Range from to) = lbracket
+                        <> text (show from)
+                        <> comma
+                       <+> text (show to)
+                        <> rparen
+
+prettyName :: Name -> Doc
+prettyName = red . text . unpackName
+
+prettySimpleType :: Int32 -> Doc
+prettySimpleType = pretty . (fromIntegral :: Int32 -> Int){-. toSimpleType-} -- TODO: make this generic to work with the analysis domain
+
+prettyReg :: Maybe IRMap -> Reg -> Doc
+prettyReg mirm reg@(Reg a) = regName <> (green $ text "@" <> (integer $ fromIntegral a)) where
+  regName = maybe empty (\irm -> maybe empty (encloseSep lbrace rbrace comma . map prettyName . Set.toList) $ Map.lookup reg $ irmRegisterMap irm) mirm
+
+prettyTag :: Maybe IRMap -> Tag -> Doc
+prettyTag mirm tag@(Tag a) = parens (integer $ fromIntegral a) <> tagName where
+  tagName = maybe empty (\irm -> pretty $ irmTagMap irm Bimap.!> tag) mirm
+
+prettySelector :: Maybe IRMap -> Selector -> Doc
+prettySelector mirm = \case
+  NodeItem tag idx          -> prettyTag mirm tag <> brackets (pretty idx)
+  ConditionAsSelector cond  -> prettyCondition mirm cond
+  AllFields                 -> text "all fields"
+
+prettyCondition :: Maybe IRMap -> Condition -> Doc
+prettyCondition mirm = \case
+    NodeTypeExists  tag -> prettyTag mirm tag <+> text "exists in"
+    SimpleTypeExists ty -> prettySimpleType ty <> text "#" <> (integer $ fromIntegral ty) <+> text "exists in"
+    AnyNotIn       tags -> text "any not in" <+> list (map (prettyTag mirm) $ Set.toList tags)
+    Any       predicate -> text "any" <+> prettyPredicate mirm predicate False
+
+prettyConstant :: Maybe IRMap -> Constant -> Doc
+prettyConstant mirm = \case
+    CSimpleType a   -> ppS a
+    CHeapLocation a -> pretty a
+    CNodeType tag arity -> ppT tag <> angles (pretty arity)
+    CNodeItem tag idx a -> ppT tag <> brackets (pretty idx) <> text "=" <> (
+      if a < 0
+        then ppS a
+        else pretty . Mem $ fromIntegral a
+      )
+  where
+    ppT = prettyTag mirm
+    ppS a = prettySimpleType a <> text "#" <> (integer $ fromIntegral a)
+
+prettyPredicate :: Maybe IRMap -> Predicate -> Bool -> Doc
+prettyPredicate mirm predicate plural = case predicate of
+  TagIn     tags -> text ("tag" ++ s ++ " in") <+> list (map (prettyTag mirm) $ Set.toList tags)
+  TagNotIn  tags -> text ("tag" ++ s ++ " not in") <+> list (map (prettyTag mirm) $ Set.toList tags)
+  ValueIn    rng -> text ("value" ++ s ++ " in") <+> pretty rng
+  ValueNotIn rng -> text ("value" ++ s ++ " not in") <+> pretty rng
+  where s = if plural then "s" else ""
+
+prettyInstruction :: Maybe IRMap -> Instruction -> Doc
+prettyInstruction mirm = \case
+    If      {..} -> keyword "if" <+> prettyCondition mirm condition <+> ppR srcReg <$$> indent 2 (vsep . map (prettyInstruction mirm) $ instructions)
+    Project {..} -> keyword "project" <+> ppS srcSelector <+> ppR srcReg <+> arr <+> ppR dstReg
+    Extend  {..} -> keyword "extend" <+> ppR srcReg <+> ppS dstSelector <+> arr <+> ppR dstReg
+    Move    {..} -> keyword "move" <+> ppR srcReg <+> arr <+> ppR dstReg
+    RestrictedMove {..} -> keyword "restricted move" <+> ppR srcReg <+> arr <+> ppR dstReg
+    ConditionalMove {..} -> keyword "conditional move" <+> parens (prettyPredicate mirm predicate False) <+> ppR srcReg <+> arr <+> ppR dstReg
+    Fetch   {..} -> keyword "fetch" <+> ppR addressReg <+> arr <+> ppR dstReg
+    Store   {..} -> keyword "store" <+> ppR srcReg <+> arr <+> pretty address
+    Update  {..} -> keyword "update" <+> ppR srcReg <+> arr <+> ppR addressReg
+    RestrictedUpdate  {..} -> keyword "restricted update" <+> ppR srcReg <+> arr <+> ppR addressReg
+    Set     {..} -> keyword "set" <+> prettyConstant mirm constant <+> arr <+> ppR dstReg
+  where
+    ppR = prettyReg mirm
+    ppS = prettySelector mirm
+    arr = text "-->"
+
+prettyInstructions :: Maybe AbstractMapping -> [Instruction] -> Doc
+prettyInstructions mp = vsep . map (prettyInstruction mirm) where
+  mirm = toIRMap <$> mp
+  toIRMap hpt = IRMap
+    { irmRegisterMap  = Map.unionsWith mappend [Map.singleton reg (Set.singleton name) | (name,reg) <- Map.toList $ _absRegisterMap hpt]
+    , irmTagMap       = _absTagMap hpt
+    }

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/Reduce.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/Reduce.hs
@@ -1,0 +1,297 @@
+{-# LANGUAGE LambdaCase, RecordWildCards, TemplateHaskell, ViewPatterns #-}
+{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
+module AbstractInterpretation.ExtendedSyntax.Reduce where
+
+import Control.DeepSeq
+import Data.Int
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import Data.Vector (Vector)
+import qualified Data.Vector as V
+import qualified Data.Bimap as Bimap
+import qualified Data.Foldable
+import Data.Maybe
+import Data.Function (on)
+import GHC.Generics (Generic)
+import System.IO.Unsafe
+
+import Control.Monad.State.Strict
+import Lens.Micro.Platform
+
+import AbstractInterpretation.ExtendedSyntax.IR
+import AbstractInterpretation.ExtendedSyntax.Util
+
+newtype NodeSet = NodeSet {_nodeTagMap :: Map Tag (Vector (Set Int32))}
+  deriving (Eq, Show, Generic, NFData)
+
+data Value
+  = Value
+  { _simpleType :: !(Set Int32)
+  , _nodeSet    :: !(NodeSet)
+  }
+  deriving (Eq, Show, Generic, NFData)
+
+data ComputerState
+  = ComputerState
+  { _memory    :: !(Vector NodeSet)
+  , _register  :: !(Vector Value)
+  }
+  deriving (Eq, Show, Generic, NFData)
+
+data AbstractInterpretationResult
+  = AbsIntResult
+  { _airComp :: !ComputerState
+  , _airIter :: !Int
+  }
+  deriving (Eq, Show, Generic, NFData)
+
+concat <$> mapM makeLenses [''NodeSet, ''Value, ''ComputerState, ''AbstractInterpretationResult]
+
+type AbstractComputation = StateT ComputerState IO
+
+instance Semigroup NodeSet where (<>)   = unionNodeSet
+instance Monoid    NodeSet where mempty = NodeSet mempty
+
+instance Semigroup Value where (<>)   = unionValue
+instance Monoid    Value where mempty = Value mempty mempty
+
+unionNodeSet :: NodeSet -> NodeSet -> NodeSet
+unionNodeSet (NodeSet x) (NodeSet y) = NodeSet $ Map.unionWith unionNodeData x y where
+  unionNodeData a b
+    | V.length a == V.length b = V.zipWith Set.union a b
+    | otherwise = error $ "node arity mismatch " ++ show (V.length a) ++ " =/= " ++ show (V.length b)
+
+unionValue :: Value -> Value -> Value
+unionValue a b = Value
+  { _simpleType = Set.union (_simpleType a) (_simpleType b)
+  , _nodeSet    = unionNodeSet (_nodeSet a) (_nodeSet b)
+  }
+
+regIndex :: Reg -> Int
+regIndex (Reg i) = fromIntegral i
+
+memIndex :: Mem -> Int
+memIndex (Mem i) = fromIntegral i
+
+selectLoc l = memory.ix (fromIntegral l)
+
+selectReg r = register.ix (regIndex r)
+
+selectSimpleType r = selectReg r.simpleType
+
+selectTagMap r = selectReg r.nodeSet.nodeTagMap
+
+move :: Reg -> Reg -> AbstractComputation ()
+move srcReg dstReg = do
+  value <- use $ selectReg srcReg
+  selectReg dstReg %= (mappend value)
+
+inRange :: Int32 -> Range -> Bool
+inRange n (Range from to) = from <= n && n < to
+
+notInRange :: Int32 -> Range -> Bool
+notInRange n = not . inRange n
+
+conditionalMoveValue :: Value -> Predicate -> Value -> Value
+conditionalMoveValue (Value st1 ns1) predicate (Value st2 ns2) =
+  let movedSt = conditionalMoveSimpleType st1 predicate st2
+      movedNs = conditionalMoveNodeSet ns1 predicate ns2
+  in Value movedSt movedNs
+
+conditionalMoveSimpleType :: Set Int32 -> Predicate -> Set Int32 -> Set Int32
+conditionalMoveSimpleType srcSet predicate dstSet =
+  case predicate of
+    ValueIn rng ->
+      let filteredSrcSet = Set.filter (`inRange` rng) srcSet
+      in  mappend filteredSrcSet dstSet
+    ValueNotIn rng ->
+      let filteredSrcSet = Set.filter (`notInRange` rng) srcSet
+      in  mappend filteredSrcSet dstSet
+    _ -> mappend srcSet dstSet
+
+conditionalMoveNodeSet :: NodeSet -> Predicate -> NodeSet -> NodeSet
+conditionalMoveNodeSet (NodeSet srcTagMap) predicate dstNS@(NodeSet dstTagMap) =
+  case predicate of
+    TagIn tagSet ->
+      let restrictedSrcNS = NodeSet $ Map.restrictKeys srcTagMap tagSet
+      in  mappend restrictedSrcNS dstNS
+    TagNotIn tagSet ->
+      let restrictedSrcNS = NodeSet $ Map.withoutKeys srcTagMap tagSet
+      in  mappend restrictedSrcNS dstNS
+    ValueIn rng ->
+      let filteredSrcNS = NodeSet $ Map.map (V.map (Set.filter (`inRange` rng))) srcTagMap
+      in mappend filteredSrcNS dstNS
+    ValueNotIn rng ->
+      let filteredSrcNS = NodeSet $ Map.map (V.map (Set.filter (`notInRange` rng))) srcTagMap
+      in mappend filteredSrcNS dstNS
+
+-- Note the existential quantifier for the simpleTypes.
+-- A field only satisfies the predicate
+-- if it actually has a value inside it that satisfies the predicate.
+valPredicateCondition :: ((Set Int32 -> Bool) -> [Set Int32] -> Bool)
+                      -> (Int32 -> Bool)
+                      -> Value
+                      -> Bool
+valPredicateCondition quantifier predicate (Value st ns) =
+  let nsVals = concatMap V.toList . Map.elems . _nodeTagMap $ ns
+      vals   = st : nsVals
+  in quantifier (any predicate) vals
+
+mappendIf :: Monoid m => (m -> Bool) -> m -> m -> m
+mappendIf predicate lhs rhs
+  | predicate rhs = mappend lhs rhs
+  | otherwise     = rhs
+
+evalInstruction :: Instruction -> AbstractComputation ()
+evalInstruction = \case
+  If {..} -> do
+    satisfy <- case condition of
+      NodeTypeExists tag -> do
+        tagMap <- use $ selectTagMap srcReg
+        pure $ Map.member tag tagMap
+      SimpleTypeExists ty -> do
+        typeSet <- use $ selectReg srcReg.simpleType
+        pure $ Set.member ty typeSet
+      AnyNotIn tags -> do
+        tagMap <- use $ selectTagMap srcReg
+        typeSet <- use $ selectReg srcReg.simpleType
+        pure $ not (Set.null typeSet) || Data.Foldable.any (`Set.notMember` tags) (Map.keysSet tagMap)
+      Any (TagIn tagSet) -> do
+        tagMap <- use $ selectTagMap srcReg
+        let tags = Map.keysSet tagMap
+        pure $ any (`Set.member` tagSet) tags
+      Any (TagNotIn tagSet) -> do
+        tagMap <- use $ selectTagMap srcReg
+        let tags = Map.keysSet tagMap
+        pure $ any (`Set.notMember` tagSet) tags
+      Any (ValueIn rng) -> do
+        val <- use $ selectReg srcReg
+        pure $ valPredicateCondition any (`inRange` rng) val
+      Any (ValueNotIn rng) -> do
+        val <- use $ selectReg srcReg
+        pure $ valPredicateCondition any (`notInRange` rng) val
+    when satisfy $ mapM_ evalInstruction instructions
+
+  Project {..} -> case srcSelector of
+    NodeItem tag itemIndex -> do
+      value <- use $ selectTagMap srcReg.at tag.non mempty.ix itemIndex
+      selectReg dstReg.simpleType %= (mappend value)
+
+    ConditionAsSelector cond -> case cond of
+      NodeTypeExists tag -> do
+        tagMap <- use $ selectTagMap srcReg
+        case Map.lookup tag tagMap of
+          Nothing -> pure ()
+          Just v  -> selectReg dstReg.nodeSet %= (mappend $ NodeSet $ Map.singleton tag v)
+
+      SimpleTypeExists ty -> do
+        typeSet <- use $ selectReg srcReg.simpleType
+        when (Set.member ty typeSet) $ do
+          selectReg dstReg.simpleType %= (Set.insert ty)
+
+      AnyNotIn tags -> do
+        tagMap <- use $ selectTagMap srcReg
+        typeSet <- use $ selectReg srcReg.simpleType
+        let filteredTagMap = Map.withoutKeys tagMap tags
+        when (not (Set.null typeSet) || not (Map.null filteredTagMap)) $ do
+          selectReg dstReg.nodeSet %= (mappend $ NodeSet filteredTagMap)
+          selectReg dstReg.simpleType %= (mappend typeSet)
+
+    AllFields -> do
+      tagMap <- use $ selectTagMap srcReg
+      -- the union of the value sets of all fields
+      let mergedFields = mconcat . (map Data.Foldable.fold) . Map.elems $ tagMap
+      selectReg dstReg.simpleType %= (mappend mergedFields)
+
+    EveryNthField n -> do
+      tagMap <- use $ selectTagMap srcReg
+      let mergedNthFields = mconcat . mapMaybe (V.!? n) . Map.elems $ tagMap
+      selectReg dstReg.simpleType %= (mappend mergedNthFields)
+
+  Extend {..} -> do
+    -- TODO: support all selectors
+    value <- use $ selectReg srcReg.simpleType
+    case dstSelector of
+      NodeItem tag itemIndex -> selectTagMap dstReg.at tag.non mempty.ix itemIndex %= (mappend value)
+      AllFields -> selectTagMap dstReg %= (Map.map (V.map (mappend value)))
+      EveryNthField n -> selectTagMap dstReg %= (Map.map (over (ix n) (mappend value)))
+      ConditionAsSelector cond -> case cond of
+        _ -> pure () -- TODO
+
+  Move {..} -> move srcReg dstReg
+
+  RestrictedMove {..} -> do
+    srcTypeSet <- use $ selectSimpleType srcReg
+    selectReg dstReg.simpleType %= (mappend srcTypeSet)
+
+    srcTagMap <- use $ selectTagMap srcReg
+    dstTagMap <- use $ selectTagMap dstReg
+
+    let restrictedSrcNodeSet = NodeSet $ Map.intersection srcTagMap dstTagMap
+    selectReg dstReg.nodeSet %= (mappend restrictedSrcNodeSet)
+
+  ConditionalMove {..} -> do
+    srcVal <- use $ selectReg srcReg
+    selectReg dstReg %= (conditionalMoveValue srcVal predicate)
+
+  Fetch {..} -> do
+    addressSet <- use $ register.ix (regIndex addressReg).simpleType
+    forM_ addressSet $ \address -> when (address >= 0) $ do
+      value <- use $ memory.ix (fromIntegral address)
+      selectReg dstReg.nodeSet %= (mappend value)
+
+  Store {..} -> do
+    value <- use $ selectReg srcReg.nodeSet
+    memory.ix (memIndex address) %= (mappend value)
+
+  Update {..} -> do
+    value <- use $ selectReg srcReg.nodeSet
+    addressSet <- use $ register.ix (regIndex addressReg).simpleType
+    forM_ addressSet $ \address -> when (address >= 0) $ do
+      memory.ix (fromIntegral address) %= (mappend value)
+
+  RestrictedUpdate {..} -> do
+    srcTagMap  <- use $ selectTagMap srcReg
+    addressSet <- use $ register.ix (regIndex addressReg).simpleType
+    forM_ addressSet $ \address -> when (address >= 0) $ do
+      locTagMap <- use $ selectLoc address.nodeTagMap
+      let restrictedSrcNodeSet = NodeSet $ Map.intersection srcTagMap locTagMap
+      selectLoc address %= (mappend restrictedSrcNodeSet)
+
+  ConditionalUpdate {..} -> do
+    srcVal <- use $ selectReg srcReg.nodeSet
+    addressSet <- use $ register.ix (regIndex addressReg).simpleType
+    forM_ addressSet $ \address -> when (address >= 0) $
+      selectLoc address %= (conditionalMoveNodeSet srcVal predicate)
+
+  Set {..} -> case constant of
+    CSimpleType ty        -> selectReg dstReg.simpleType %= (mappend $ Set.singleton ty)
+    CHeapLocation (Mem l) -> selectReg dstReg.simpleType %= (mappend $ Set.singleton $ fromIntegral l)
+    CNodeType tag arity   -> selectReg dstReg.nodeSet %= (mappend $ NodeSet . Map.singleton tag $ V.replicate arity mempty)
+    CNodeItem tag idx val -> selectReg dstReg.nodeSet.nodeTagMap.at tag.non mempty.ix idx %= (mappend $ Set.singleton val)
+
+continueAbstractProgramWithIO :: ComputerState -> AbstractProgram -> IO AbstractInterpretationResult
+continueAbstractProgramWithIO comp AbstractProgram{..} = loop (AbsIntResult comp 0) where
+  loop air = do
+    air' <- force <$> step air
+    if (_airComp air == _airComp air')
+      then pure air
+      else loop air'
+
+  nextComputer c = execStateT (mapM_ evalInstruction _absInstructions) c
+  step AbsIntResult{..} = AbsIntResult <$> (nextComputer _airComp) <*> (pure $ succ _airIter)
+
+evalAbstractProgramIO :: AbstractProgram -> IO AbstractInterpretationResult
+evalAbstractProgramIO p@AbstractProgram{..} = continueAbstractProgramWithIO emptyComputer p where
+  emptyComputer = ComputerState
+    { _memory   = V.replicate (fromIntegral _absMemoryCounter) mempty
+    , _register = V.replicate (fromIntegral _absRegisterCounter) mempty
+    }
+
+evalAbstractProgram :: AbstractProgram -> AbstractInterpretationResult
+evalAbstractProgram a = unsafePerformIO $ evalAbstractProgramIO a
+
+continueAbstractProgramWith :: ComputerState -> AbstractProgram -> AbstractInterpretationResult
+continueAbstractProgramWith s p = unsafePerformIO $ continueAbstractProgramWithIO s p

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/ReduceCpp.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/ReduceCpp.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE LambdaCase, RecordWildCards, Strict #-}
+module AbstractInterpretation.ExtendedSyntax.ReduceCpp where
+
+import qualified Data.ByteString.Lazy as LBS
+import qualified System.Process
+import System.IO.Unsafe
+
+import AbstractInterpretation.ExtendedSyntax.IR
+import AbstractInterpretation.ExtendedSyntax.Reduce (AbstractInterpretationResult)
+import AbstractInterpretation.ExtendedSyntax.BinaryResult
+import AbstractInterpretation.ExtendedSyntax.BinaryIR
+
+evalAbstractProgramCpp :: AbstractProgram -> IO AbstractInterpretationResult
+evalAbstractProgramCpp prg = do
+  -- save abstract program to temp file
+  LBS.writeFile "dataflow_program.dfbin" $ encodeAbstractProgram prg
+
+  -- run external reducer
+  System.Process.callCommand "df_test dataflow_program.dfbin"
+
+  -- read back result
+  loadAbstractInterpretationResult "dataflow_program.dfbin.dat"
+
+evalAbstractProgramCppUnsafe :: AbstractProgram -> AbstractInterpretationResult
+evalAbstractProgramCppUnsafe a = unsafePerformIO $ evalAbstractProgramCpp a

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/Util.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/Util.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE LambdaCase, RecordWildCards #-}
+module AbstractInterpretation.ExtendedSyntax.Util where
+
+converge :: (a -> a -> Bool) -> (a -> a) -> a -> a
+converge pred f x
+  | pred x x' = x
+  | otherwise = converge pred f x'
+  where x' = f x

--- a/grin/src/Grin/ExtendedSyntax/Lint.hs
+++ b/grin/src/Grin/ExtendedSyntax/Lint.hs
@@ -304,6 +304,7 @@ lint warningKinds mTypeEnv exp@(Program exts _) =
       let lhsCtx = if isn't _OnlyVarPat bPat then SEWithoutNodesCtx else SimpleExpCtx
       check (EBindF (lhsCtx, leftExp) bPat (ExpCtx, rightExp)) $ do
         syntaxE ExpCtx
+        -- QUESTION: Is this needed wit hthe new syntax? Undefined introduction is still an open question.
         when (isFetchF leftExp && isn't _OnlyVarPat bPat) (warning DDE [msg $ "The result of Fetch can only be bound to a variable: " ++ plainShow bPat])
 
         when (isn't _OnlyVarPat bPat) $ do
@@ -348,7 +349,7 @@ lint warningKinds mTypeEnv exp@(Program exts _) =
           Just st
             | has _T_Location st || has _T_String st || has _T_Float st
             -> warning Semantics [beforeMsg $ printf "case variable %s has non-supported pattern match type: %s" scrut (plainShow st)]
-          Nothing -> pure ()
+          _ -> pure () -- TODO
 
         -- Non-covered alternatives
         when (noOfDefaults == 0) $ do
@@ -357,7 +358,7 @@ lint warningKinds mTypeEnv exp@(Program exts _) =
             Just tags -> do
               forM_ tags $ \tag -> when (Map.notMember tag tagOccurences) $ do
                 warning Semantics [beforeMsg $ printf "case has non-covered alternative %s" (plainShow tag)]
-            Nothing -> pure ()
+            _ -> pure () -- TODO
 
     -- Simple Exp
     (_ :< SAppF name args) -> checkWithChild ctx $ do

--- a/grin/src/Grin/ExtendedSyntax/Lint.hs
+++ b/grin/src/Grin/ExtendedSyntax/Lint.hs
@@ -1,0 +1,454 @@
+{-# LANGUAGE ViewPatterns, LambdaCase, TupleSections, RecordWildCards, OverloadedStrings, ScopedTypeVariables #-}
+{-# LANGUAGE MultiWayIf #-}
+module Grin.ExtendedSyntax.Lint
+  ( lint
+  , allWarnings
+  , noDDEWarnings
+  , Error(..)
+  ) where
+
+import Text.Printf
+
+import Data.Functor.Foldable as Foldable
+import qualified Data.Foldable
+import Control.Comonad.Cofree
+import Control.Monad.State
+import Control.Monad.Writer hiding (Alt)
+import qualified Control.Comonad.Trans.Cofree as CCTC
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.List (findIndices)
+import Lens.Micro.Platform
+import Lens.Micro.Extra
+import Text.PrettyPrint.ANSI.Leijen (Pretty, plain)
+import Data.String
+import Control.Comonad (extract)
+import qualified Data.Vector as Vector
+import Control.Applicative (liftA2)
+import Data.Functor.Infix ((<$$>))
+
+import Grin.ExtendedSyntax.Grin
+import Grin.ExtendedSyntax.Pretty
+import Grin.ExtendedSyntax.TypeEnv hiding (typeOfVal)
+import Transformations.ExtendedSyntax.Util
+
+import Debug.Trace
+import Data.Maybe
+
+{-
+Linter is responsible for the semantical checks of the program.
+-}
+
+{-
+  - AST shape (syntax)
+    done - exp
+    - val
+  - recognise primitive functions
+  - scope checking ; requires monad (full traversal)
+  - type checking (using the type env)
+  - pattern checking
+  - node item checking (no node in node)
+  - case:
+    - overlapping alternatives
+    - uncovered cases
+    - fully saturated alternatives
+  - fully saturated node creation eg (CPair 1 2) vs (CPair 1)
+-}
+
+{-
+  question:
+    how to show errors?
+      - annotate expressions with the error using cofree
+      - annotate expressionf with id using cofree, then build error map referencing to expressions
+-}
+
+data Error = Error
+  { before  :: Bool
+  , message :: String
+  }
+
+msg :: String -> Error
+msg = Error False
+
+beforeMsg :: String -> Error
+beforeMsg = Error True
+
+data ExpCtx
+  = ProgramCtx
+  | DefCtx
+  | ExpCtx
+  | SimpleExpCtx
+  | SEWithoutNodesCtx
+  | AltCtx
+  deriving Eq
+
+data ValCtx
+  = ValCtx
+  | SimpleValCtx
+  deriving Eq
+
+showExpCtx :: ExpCtx -> String
+showExpCtx = \case
+  ProgramCtx        -> "Program"
+  DefCtx            -> "Def"
+  ExpCtx            -> "Exp"
+  SimpleExpCtx      -> "SimpleExp"
+  SEWithoutNodesCtx -> "SimpleExp without nodes"
+  AltCtx            -> "Alt"
+
+showValCtx :: ValCtx -> String
+showValCtx = \case
+  ValCtx        -> "Val"
+  SimpleValCtx  -> "SimpleVal"
+
+data Env
+  = Env
+  { envNextId       :: Int
+  , envVars         :: Map Name Int -- exp id
+  , envErrors       :: Map Int [Error]
+  , envDefinedNames :: Map Name DefRole
+  , envFunArity     :: Map Name Int
+  , envWarningKinds :: [WarningKind] -- Allowed warning kinds
+  }
+
+emptyEnv = Env
+  { envNextId       = 0
+  , envVars         = mempty
+  , envErrors       = mempty
+  , envDefinedNames = mempty
+  , envFunArity     = mempty
+  , envWarningKinds = []
+  }
+
+type Lint   = State Env
+type Check  = WriterT [Error] Lint
+type TypedExp = Cofree ExpF (Maybe Type)
+
+expId :: Lint Int
+expId = gets envNextId
+
+nextId :: Lint ()
+nextId = modify' $ \env@Env{..} -> env {envNextId = succ envNextId}
+
+{-
+  TODO:
+    type check
+-}
+
+data WarningKind
+  = Syntax
+  | Semantics
+  | DDE
+  deriving (Enum, Eq, Ord, Show)
+
+allWarnings :: [WarningKind]
+allWarnings = [Syntax .. DDE]
+
+noDDEWarnings :: [WarningKind]
+noDDEWarnings = [Syntax, Semantics]
+
+warning :: WarningKind -> [Error] -> Check ()
+warning w m = do
+  ws <- gets envWarningKinds
+  when (w `elem` ws) $
+    tell m
+
+syntaxVal :: ValCtx -> Val -> Check Bool
+syntaxVal ctx = \case
+  Lit{} -> pure True
+  Var{} -> pure True
+
+  Undefined (T_NodeSet{})
+    | ctx == ValCtx -> pure True
+
+  _ | ctx == ValCtx -> pure True
+
+  _ -> warning Syntax [msg $ "Syntax error - expected " ++ showValCtx ctx] >> pure False
+
+syntaxVal_ :: ValCtx -> Val -> Check ()
+syntaxVal_ = void <$$> syntaxVal
+
+{-
+  ConstTagNode  Tag  [SimpleVal] -- complete node (constant tag) ; HIGH level GRIN
+  VarTagNode    Name [SimpleVal] -- complete node (variable tag)
+  ValTag        Tag
+  Unit                           -- HIGH level GRIN
+  Lit Lit                        -- HIGH level GRIN
+  Var Name                       -- HIGH level GRIN
+-}
+
+syntaxExp :: ExpCtx -> ExpCtx -> Check ()
+syntaxExp expected given | given == expected = pure ()
+syntaxExp ExpCtx SimpleExpCtx = pure ()
+syntaxExp SimpleExpCtx SEWithoutNodesCtx = pure ()
+syntaxExp ExpCtx SEWithoutNodesCtx = pure ()
+syntaxExp expected _ = warning Syntax [msg $ "Syntax error - expected " ++ showExpCtx expected]
+
+checkNameDef :: DefRole -> Name -> Check ()
+checkNameDef role name = do
+  defined <- state $ \env@Env{..} ->
+    ( Map.member name envDefinedNames
+    , env {envDefinedNames = Map.insert name role envDefinedNames}
+    )
+  when defined $ do
+    warning Semantics [msg $ printf "multiple defintion of %s" name]
+
+checkNameUse :: Name -> Check ()
+checkNameUse name = do
+  defined <- state $ \env@Env{..} -> (Map.member name envDefinedNames, env)
+  unless defined $ do
+    warning Syntax [msg $ printf "undefined variable: %s" name]
+
+checkVarScopeM :: ExpF a -> Check ()
+checkVarScopeM exp = do
+  case exp of
+    DefF _ _ _ -> pure () -- Function definitions are already registered
+    _          -> mapM_ (uncurry checkNameDef) $ foldNameDefExpF (\r n -> [(r,n)]) exp
+  mapM_ checkNameUse $ foldNameUseExpF (:[]) exp
+
+plainShow :: (Pretty p) => p -> String
+plainShow = show . plain . pretty
+
+unionSType :: SimpleType -> SimpleType -> Maybe SimpleType
+unionSType (T_Location l1) (T_Location l2) = Just $ T_Location (l1 ++ l2)
+unionSType T_Dead t = Just t
+unionSType t T_Dead = Just t
+unionSType t1 t2
+  | t1 == t2 = Just t1
+  | otherwise = Nothing
+
+unionType :: Type -> Type -> Maybe Type
+unionType (T_SimpleType t1) (T_SimpleType t2) = T_SimpleType <$> unionSType t1 t2
+unionType (T_NodeSet ns1) (T_NodeSet ns2) =
+  fmap T_NodeSet
+  $ sequenceA
+  $ Map.map (fmap Vector.fromList . sequenceA)
+  $ Map.unionWith (zipWith (join <$$> liftA2 unionSType)) (Map.map (map Just . Vector.toList) ns1) (Map.map (map Just . Vector.toList) ns2)
+unionType _ _ = Nothing
+
+annotate :: TypeEnv -> Exp -> TypedExp
+annotate te = cata builder where
+  builder :: ExpF TypedExp -> TypedExp
+  builder = \case
+    ProgramF exts defs -> Nothing :< ProgramF exts defs
+    DefF n ps body -> (te ^? function . at n . _Just . _1) :< DefF n ps body
+    SReturnF val -> mTypeOfValTE te val :< SReturnF val
+    SStoreF val -> Nothing :< SStoreF val -- Store returns a location type that is associated in its binded variable
+    SUpdateF name val -> Just unit_t :< SUpdateF name val
+    SFetchF var ->
+      (do locs <- mTypeOfValTE te (Var var) ^? _Just . _T_SimpleType . _T_Location
+          let (n:ns) = catMaybes $ map (\l -> te ^? location . at l . _Just . to T_NodeSet) locs
+          foldM unionType n ns
+      )
+      :< SFetchF var -- Fetch returns a value based on its arguments that is associated in its binded variable
+    SAppF f params -> (te ^? function . at f . _Just . _1) :< SAppF f params
+    AltF cpat body -> extract body :< AltF cpat body
+    ECaseF var alts ->
+      (do case catMaybes $ map extract alts of
+            [] -> Nothing
+            (t:ts) -> foldM unionType t ts)
+      :< ECaseF var alts
+    EBindF lhs pat rhs -> extract rhs :< EBindF lhs pat rhs
+    SBlockF body -> extract body :< SBlockF body
+
+noAnnotation :: Exp -> TypedExp
+noAnnotation = cata (Nothing :<)
+
+check :: ExpF (ExpCtx, TypedExp) -> Check () -> Lint (CCTC.CofreeF ExpF Int (ExpCtx, TypedExp))
+check exp nodeCheckM = do
+  idx <- expId
+  errors <- execWriterT (nodeCheckM >> checkVarScopeM exp)
+  unless (null errors) $ do
+    modify' $ \env@Env{..} -> env {envErrors = Map.insert idx errors envErrors}
+  nextId
+  pure (idx CCTC.:< exp )
+
+lint :: [WarningKind] -> Maybe TypeEnv -> Exp -> (Cofree ExpF Int, Map Int [Error])
+lint warningKinds mTypeEnv exp@(Program exts _) =
+  fmap envErrors $ flip runState (emptyEnv { envWarningKinds = warningKinds }) $ do
+    cata functionNames exp
+    anaM builder (ProgramCtx, maybe noAnnotation annotate mTypeEnv exp)
+  where
+  functionNames :: ExpF (Lint ()) -> Lint ()
+  functionNames = \case
+    ProgramF exts defs -> sequence_ defs
+    DefF name args body -> do
+      modify' $ \env@Env{..} -> env
+        { envDefinedNames = Map.insert name FunName envDefinedNames
+        , envFunArity = Map.insert name (length args) envFunArity
+        }
+      forM_ args $ \p -> modify' $ \env@Env{..} -> env { envDefinedNames = Map.insert p FunParam envDefinedNames }
+      body
+    rest -> pure ()
+
+  builder :: (ExpCtx, TypedExp) -> Lint (CCTC.CofreeF ExpF Int (ExpCtx, TypedExp))
+  builder (ctx, e) = case e of
+
+    (_ :< ProgramF{}) -> checkWithChild DefCtx $ do
+      syntaxE ProgramCtx
+
+    (_ :< DefF name args _) -> checkWithChild ExpCtx $ do
+      syntaxE DefCtx
+
+    -- Exp
+    -- The result Fetch should be bound to a variable to make DDE simpler
+    (_ :< EBindF leftExp bPat rightExp) -> do
+      -- TODO: is this really needed?
+      let lhsCtx = if isn't _OnlyVarPat bPat then SEWithoutNodesCtx else SimpleExpCtx
+      check (EBindF (lhsCtx, leftExp) bPat (ExpCtx, rightExp)) $ do
+        syntaxE ExpCtx
+        when (isFetchF leftExp && isn't _OnlyVarPat bPat) (warning DDE [msg $ "The result of Fetch can only be bound to a variable: " ++ plainShow bPat])
+
+        when (isn't _OnlyVarPat bPat) $ do
+          forM_ mTypeEnv $ \typeEnv -> do
+            fromMaybe (pure ()) $ case bPat of
+              AsPat v val -> do -- Maybe
+                expectedPatType <- normalizeType <$> mTypeOfValTE typeEnv val
+                lhsType         <- normalizeType <$> extract leftExp
+                pure $ do -- Lint
+                  -- NOTE: This can still give false positive errors, because bottom-up typing can only approximate the result of HPT.
+                  when (sameType expectedPatType lhsType == Just False) $ do
+                    warning Semantics $ [beforeMsg $ unwords
+                      ["Invalid pattern match for", plainShow bPat ++ "." , "Expected pattern of type:", plainShow expectedPatType ++ ",", "but got:", plainShow lhsType]]
+
+    (_ :< ECaseF scrut alts0) -> checkWithChild AltCtx $ do
+      syntaxE SEWithoutNodesCtx
+      let alts = getF <$> alts0
+      -- Overlapping node alternatives
+      let tagOccurences =
+            Map.unionsWith (+) $
+            map (`Map.singleton` 1) $
+            concatMap (^.. _AltFCPat . _CPatNodeTag) alts
+      forM_ (Map.keys $ Map.filter (>1) tagOccurences) $ \(tag :: Tag) ->
+        warning Semantics [beforeMsg $ printf "case has overlapping node alternatives %s" (plainShow tag)]
+      -- Overlapping literal alternatives
+      let literalOccurences =
+            Map.unionsWith (+) $
+            map (`Map.singleton` 1) $
+            concatMap (^.. _AltFCPat . _CPatLit) alts
+      forM_ (Map.keys $ Map.filter (>1) literalOccurences) $ \(lit :: Lit) ->
+        warning Semantics [beforeMsg $ printf "case has overlapping literal alternatives %s" (plainShow lit)]
+
+      let noOfDefaults = length $ findIndices (has (_AltFCPat . _CPatDefault)) alts
+      -- More than one default
+      when (noOfDefaults > 1) $ do
+        warning Semantics [beforeMsg $ "case has more than one default alternatives"]
+
+      forM_ mTypeEnv $ \typeEnv -> do
+        -- Case variable has a location type
+        let mSt = typeEnv ^? variable . at scrut . _Just . _T_SimpleType
+        case mSt of
+          Just st
+            | has _T_Location st || has _T_String st || has _T_Float st
+            -> warning Semantics [beforeMsg $ printf "case variable %s has non-supported pattern match type: %s" scrut (plainShow st)]
+          Nothing -> pure ()
+
+        -- Non-covered alternatives
+        when (noOfDefaults == 0) $ do
+          let mTags = typeEnv ^? variable . at scrut . _Just . _T_NodeSet . to Map.keys
+          case mTags of
+            Just tags -> do
+              forM_ tags $ \tag -> when (Map.notMember tag tagOccurences) $ do
+                warning Semantics [beforeMsg $ printf "case has non-covered alternative %s" (plainShow tag)]
+            Nothing -> pure ()
+
+    -- Simple Exp
+    (_ :< SAppF f args) -> checkWithChild ctx $ do
+      syntaxE SEWithoutNodesCtx
+      -- Test existence of the function.
+      Env{..} <- get
+      unless (isExternalName exts f) $
+        case Map.lookup f envDefinedNames of
+          (Just FunName) -> pure ()
+          (Just _)       -> warning Syntax [msg $ printf "non-function in function call: %s" f]
+          Nothing        -> warning Syntax [msg $ printf "non-defined function is called: %s" f]
+      -- Non saturated function call
+      forM_ (Map.lookup f envFunArity) $ \n -> when (n /= length args) $ do
+        warning Syntax [msg $ printf "non-saturated function call: %s" f]
+
+    -- Only simple values should be returned,
+    -- unless the returned value is bound to a variable.
+    -- In that case the Return node is a left-hand side of a binding,
+    -- which means it is inside a SimpleExpCtx.
+    -- This is becuase only binding left-hand sides can be in SimpleExpCtx.
+    (_ :< SReturnF val) -> checkWithChild ctx $ do
+      (onlySimpleVals,errs) <- censorListen $ syntaxVal SimpleValCtx val
+      let hasNoNodes = val == Unit || onlySimpleVals
+      case ctx of
+        -- last expression in a binding sequence or a single, standalone expression
+        ExpCtx | hasNoNodes -> syntaxE SEWithoutNodesCtx
+               | otherwise  -> warning DDE [msg $ "Last return expressions can only return non-node values: " ++ plainShow (SReturn val)]
+        -- lhs of a binding
+        SimpleExpCtx | hasNoNodes -> syntaxE SEWithoutNodesCtx
+        -- lhs of a bidning where the LPat is not a variable
+        SEWithoutNodesCtx | hasNoNodes -> syntaxE SEWithoutNodesCtx
+
+        _ -> syntaxE SimpleExpCtx
+
+    (_ :< SStoreF arg) -> checkWithChild ctx $ do
+      syntaxE SEWithoutNodesCtx
+      forM_ mTypeEnv $ \typeEnv -> do
+        -- Store has given a primitive type
+        let mTags = typeEnv ^? variable . at arg . _Just . _T_NodeSet . to Map.keys
+            mSt   = typeEnv ^? variable . at arg . _Just . _T_SimpleType
+        case (mTags,mSt) of
+          (Just tags,_) -> pure ()
+          (_,  Just st) | st /= T_Dead ->
+             warning Semantics [msg $ printf "store has given a primitive value: %s :: %s" (plainShow arg) (plainShow st)]
+          _ -> pure ()
+
+    (_ :< SFetchF name) -> checkWithChild ctx $ do
+      syntaxE SEWithoutNodesCtx
+      -- Non location parameter for fetch
+      forM_ mTypeEnv $ \typeEnv -> if
+        | Just _ <- typeEnv ^? variable . at name . _Just . _T_SimpleType . _T_Location
+          -> pure ()
+        | Just st <- typeEnv ^? variable . at name . _Just . _T_SimpleType
+          -> when (st /= T_Dead) $ warning Semantics [msg $ printf "the parameter of fetch is a primitive type: %s :: %s" (plainShow name) (plainShow st)]
+        | Just ns <- typeEnv ^? variable . at name . _Just . _T_NodeSet
+          -> warning Semantics [msg $ printf "the parameter of fetch is a node type: %s" (plainShow name)]
+        | otherwise -> pure ()
+
+    (_ :< SUpdateF name arg) -> checkWithChild ctx $ do
+      syntaxE SEWithoutNodesCtx
+
+      -- Non location parameter for update
+      forM_ mTypeEnv $ \typeEnv -> if
+        | Just _ <- typeEnv ^? variable . at name . _Just . _T_SimpleType . _T_Location
+          -> pure ()
+        | Just st <- typeEnv ^? variable . at name . _Just . _T_SimpleType
+          -> when (st /= T_Dead) $ warning Semantics [msg $ printf "the parameter of update is a primitive type: %s :: %s" (plainShow name) (plainShow st)]
+        | Just ns <- typeEnv ^? variable . at name . _Just . _T_NodeSet
+          -> warning Semantics [msg $ printf "the parameter of update is a node type: %s" (plainShow name)]
+        | otherwise -> pure ()
+
+      forM_ mTypeEnv $ \typeEnv -> do
+        -- Update has given a primitive type
+        let mTags = typeEnv ^? variable . at arg . _Just . _T_NodeSet . to Map.keys
+            mSt   = typeEnv ^? variable . at arg . _Just . _T_SimpleType
+        case (mTags,mSt) of
+          (Just tags,_) -> pure ()
+          (_,  Just st) | st /= T_Dead ->
+            warning Semantics [msg $ printf "update has given a primitive value: %s :: %s" (plainShow arg) (plainShow st)]
+          _ -> pure ()
+
+    (_ :< SBlockF{}) -> checkWithChild ExpCtx $ do
+      syntaxE SEWithoutNodesCtx
+
+    -- Alt
+    (_ :< AltF cpat _) -> checkWithChild ExpCtx $ do
+      syntaxE AltCtx
+
+    where
+      syntaxE = syntaxExp ctx
+      checkWithChild childCtx m = check ((childCtx,) <$> (getF e)) m
+      getF (_ :< f) = f
+
+      isFetchF (getF -> SFetchF{}) = True
+      isFetchF _ = False
+
+      -- Collects the side-effects without appending it to the output.
+      censorListen :: (Monoid w, Monad m) => WriterT w m a -> WriterT w m (a,w)
+      censorListen = censor (const mempty) . listen

--- a/grin/src/Grin/ExtendedSyntax/PrimOpsPrelude.hs
+++ b/grin/src/Grin/ExtendedSyntax/PrimOpsPrelude.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE OverloadedStrings, QuasiQuotes, ViewPatterns #-}
+module Grin.ExtendedSyntax.PrimOpsPrelude where
+
+import Grin.ExtendedSyntax.Grin
+import Grin.ExtendedSyntax.TH
+
+{-
+  These predefined primitive operations are optional.
+  This is a utility module for front-ends and the grin CLI
+  use `grin --no-prelude` to exclude these predefined primitive operations
+-}
+
+primPrelude :: Program
+primPrelude = [progConst|
+
+  ffi effectful
+    _prim_int_print     :: T_Int64 -> T_Unit
+    _prim_usleep        :: T_Int64 -> T_Unit
+    _prim_string_print  :: T_String -> T_Unit
+    _prim_read_string   :: T_String
+    _prim_error         :: T_String -> T_Unit
+    _prim_ffi_file_eof  :: T_Int64 -> T_Int64
+
+  -- Everything that handles Strings are FFI implemented now.
+  ffi pure
+    -- String
+    _prim_string_concat  :: T_String -> T_String -> T_String
+    _prim_string_reverse :: T_String -> T_String
+    _prim_string_lt      :: T_String -> T_String -> T_Int64
+    _prim_string_eq      :: T_String -> T_String -> T_Int64
+    _prim_string_head    :: T_String -> T_Int64 -- TODO: Change to Char
+    _prim_string_tail    :: T_String -> T_String
+    _prim_string_cons    :: T_Int64  -> T_String -> T_String
+    _prim_string_len     :: T_String -> T_Int64
+
+  ffi pure
+    -- Conversion
+    _prim_int_str      :: T_Int64 -> T_String
+    _prim_str_int      :: T_String -> T_Int64
+    _prim_int_float    :: T_Int64 -> T_Float
+    _prim_float_string :: T_Float -> T_String
+    _prim_char_int     :: T_Char  -> T_Int64
+
+  primop pure
+    -- Int
+    _prim_int_shr   :: T_Int64 -> T_Int64 -- TODO: Remove?
+    _prim_int_add   :: T_Int64 -> T_Int64 -> T_Int64
+    _prim_int_sub   :: T_Int64 -> T_Int64 -> T_Int64
+    _prim_int_mul   :: T_Int64 -> T_Int64 -> T_Int64
+    _prim_int_div   :: T_Int64 -> T_Int64 -> T_Int64
+    _prim_int_ashr  :: T_Int64 -> T_Int64 -> T_Int64
+    _prim_int_eq    :: T_Int64 -> T_Int64 -> T_Bool
+    _prim_int_ne    :: T_Int64 -> T_Int64 -> T_Bool
+    _prim_int_gt    :: T_Int64 -> T_Int64 -> T_Bool
+    _prim_int_ge    :: T_Int64 -> T_Int64 -> T_Bool
+    _prim_int_lt    :: T_Int64 -> T_Int64 -> T_Bool
+    _prim_int_le    :: T_Int64 -> T_Int64 -> T_Bool
+
+    -- Word
+    _prim_word_add  :: T_Word64 -> T_Word64 -> T_Word64
+    _prim_word_sub  :: T_Word64 -> T_Word64 -> T_Word64
+    _prim_word_mul  :: T_Word64 -> T_Word64 -> T_Word64
+    _prim_word_div  :: T_Word64 -> T_Word64 -> T_Word64
+    _prim_word_eq   :: T_Word64 -> T_Word64 -> T_Bool
+    _prim_word_ne   :: T_Word64 -> T_Word64 -> T_Bool
+    _prim_word_gt   :: T_Word64 -> T_Word64 -> T_Bool
+    _prim_word_ge   :: T_Word64 -> T_Word64 -> T_Bool
+    _prim_word_lt   :: T_Word64 -> T_Word64 -> T_Bool
+    _prim_word_le   :: T_Word64 -> T_Word64 -> T_Bool
+
+    -- Float
+    _prim_float_add :: T_Float -> T_Float -> T_Float
+    _prim_float_sub :: T_Float -> T_Float -> T_Float
+    _prim_float_mul :: T_Float -> T_Float -> T_Float
+    _prim_float_div :: T_Float -> T_Float -> T_Float
+    _prim_float_eq  :: T_Float -> T_Float -> T_Bool
+    _prim_float_ne  :: T_Float -> T_Float -> T_Bool
+    _prim_float_gt  :: T_Float -> T_Float -> T_Bool
+    _prim_float_ge  :: T_Float -> T_Float -> T_Bool
+    _prim_float_lt  :: T_Float -> T_Float -> T_Bool
+    _prim_float_le  :: T_Float -> T_Float -> T_Bool
+
+    -- Bool
+    _prim_bool_eq   :: T_Bool -> T_Bool -> T_Bool
+    _prim_bool_ne   :: T_Bool -> T_Bool -> T_Bool
+
+|]
+
+withPrimPrelude :: Program -> Program
+withPrimPrelude p = concatPrograms [primPrelude, p]

--- a/grin/src/Grin/ExtendedSyntax/TypeCheck.hs
+++ b/grin/src/Grin/ExtendedSyntax/TypeCheck.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE LambdaCase, RecordWildCards, TemplateHaskell, OverloadedStrings #-}
+module Grin.ExtendedSyntax.TypeCheck where
+
+import Text.Printf
+
+import Data.Int
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Vector (Vector)
+import qualified Data.Vector as V
+
+import Data.Bifunctor
+
+import Control.Monad.Except
+import Lens.Micro.Platform
+
+import Grin.ExtendedSyntax.Grin (Tag, Exp, Name, packName)
+import Grin.ExtendedSyntax.Pretty
+import AbstractInterpretation.ExtendedSyntax.HeapPointsTo.Pretty
+import AbstractInterpretation.ExtendedSyntax.HeapPointsTo.Result as HPT
+import qualified AbstractInterpretation.ExtendedSyntax.HeapPointsTo.CodeGen as HPT
+
+import qualified Grin.ExtendedSyntax.TypeEnv as TypeEnv
+
+import AbstractInterpretation.ExtendedSyntax.Reduce (AbstractInterpretationResult(..))
+import qualified AbstractInterpretation.ExtendedSyntax.Reduce as R
+
+{-
+  validate HPT result
+         - fixed node tag arity
+    done - monomorph nodes ; each node component is
+            - singleton simple type
+            - one or more locations
+            - unspecified location
+            - dead type (empty simple typeset)
+-}
+typeEnvFromHPTResult :: HPTResult -> Either String TypeEnv.TypeEnv
+typeEnvFromHPTResult hptResult = typeEnv where
+  convertSimpleType :: SimpleType -> Either String TypeEnv.SimpleType
+  convertSimpleType = \case
+    T_Int64               -> pure TypeEnv.T_Int64
+    T_Word64              -> pure TypeEnv.T_Word64
+    T_Float               -> pure TypeEnv.T_Float
+    T_Bool                -> pure TypeEnv.T_Bool
+    T_Unit                -> pure TypeEnv.T_Unit
+    T_UnspecifiedLocation -> pure TypeEnv.T_UnspecifiedLocation
+    T_Location l          -> pure $ TypeEnv.T_Location [l]
+    T_String              -> pure TypeEnv.T_String
+    T_Char                -> pure TypeEnv.T_Char
+    l@Local{} -> throwError $ "Encountered analysis specific local value during type checking: " ++ show l
+
+  isLocation :: SimpleType -> Bool
+  isLocation = \case
+    T_Location _ -> True
+    T_UnspecifiedLocation -> True
+    _ -> False
+
+  convertSimpleTypeSet :: Name -> NodeSet -> [SimpleType] -> Either String TypeEnv.SimpleType
+  convertSimpleTypeSet _ _ [] = pure TypeEnv.T_Dead
+  convertSimpleTypeSet _ _ [sTy] = convertSimpleType sTy
+  convertSimpleTypeSet n ns tys
+    | all isLocation tys
+    -- skipping unspecified locations
+    , locs <- [l | T_Location l <- tys]
+    = if null locs then pure $ TypeEnv.T_UnspecifiedLocation
+                   else pure $ TypeEnv.T_Location locs
+    | otherwise = throwError $ printf "%s has illegal node item type %s in %s" (TypeEnv.unNM n) (show . pretty $ Set.fromList tys) (show $ pretty ns)
+
+  convertNodeSet :: Name -> NodeSet -> Either String (Map Tag (Vector TypeEnv.SimpleType))
+  convertNodeSet n a@(NodeSet ns) = mapM (mapM (convertSimpleTypeSet n a . Set.toList)) ns
+
+  convertLocation :: Int -> NodeSet -> Either String (Map Tag (Vector TypeEnv.SimpleType))
+  convertLocation loc = convertNodeSet $ "Loc " <> (packName . show $ loc)
+
+  convertTypeSet :: Name -> TypeSet -> Either String TypeEnv.Type
+  convertTypeSet n ts = do
+    let ns = ts^.nodeSet
+        st = ts^.simpleType
+    case (Set.size st, Map.size $ ns^.nodeTagMap) of
+      (stCount,nsCount) | stCount == 0 && nsCount > 0 -> TypeEnv.T_NodeSet <$> convertNodeSet n ns
+      (stCount,nsCount) | stCount > 0 && nsCount == 0 -> TypeEnv.T_SimpleType <$> convertSimpleTypeSet n ns (Set.toList st)
+      (0,0)                                           -> pure TypeEnv.dead_t
+      _ -> throwError $ printf "%s has illegal type of %s" (TypeEnv.unNM n) (show . pretty $ ts)
+
+  convertFunction :: Name -> (TypeSet, Vector TypeSet) -> Either String (TypeEnv.Type, Vector TypeEnv.Type)
+  convertFunction name (ret, args) = (,) <$> convertTypeSet name ret <*> mapM (convertTypeSet name) args
+
+  typeEnv :: Either String TypeEnv.TypeEnv
+  typeEnv = TypeEnv.TypeEnv <$>
+    (V.imapM convertLocation (_memory hptResult)) <*>
+    (Map.traverseWithKey convertTypeSet $ (_register hptResult)) <*>
+    (Map.traverseWithKey convertFunction $ (_function hptResult))
+
+inferTypeEnv :: Exp -> TypeEnv.TypeEnv
+inferTypeEnv exp = either error id $ typeEnvFromHPTResult result where
+  (hptProgram, hptMapping) = HPT.codeGen exp
+  computer = _airComp . R.evalAbstractProgram $ hptProgram
+  result = HPT.toHPTResult hptMapping computer

--- a/grin/src/Test/ExtendedSyntax/Util.hs
+++ b/grin/src/Test/ExtendedSyntax/Util.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Test.ExtendedSyntax.Util where
+
+-- TODO: Remove this module
+
+import System.FilePath
+
+import Data.Text (Text)
+import qualified Data.Text.IO as T (readFile)
+
+import Grin.ExtendedSyntax.Grin
+import Grin.ExtendedSyntax.Parse
+
+import Test.Hspec
+import Test.ExtendedSyntax.Assertions
+
+cInt :: Tag
+cInt = Tag C "Int"
+
+cBool :: Tag
+cBool = Tag C "Bool"
+
+cWord :: Tag
+cWord = Tag C "Word"
+
+cBoolH :: Tag
+cBoolH = Tag C "BoolH"
+
+cWordH :: Tag
+cWordH = Tag C "WordH"
+
+cOne :: Tag
+cOne = Tag C "One"
+
+cTwo :: Tag
+cTwo = Tag C "Two"
+
+cNode :: Tag
+cNode = Tag C "Node"
+
+cFoo :: Tag
+cFoo = Tag C "Foo"
+
+cBar :: Tag
+cBar = Tag C "Bar"
+
+cNil :: Tag
+cNil = Tag C "Nil"
+
+cCons :: Tag
+cCons = Tag C "Cons"
+
+-- name ~ name of the test case, and also the grin source file
+mkBeforeAfterTestCase :: String ->
+                         FilePath ->
+                         FilePath ->
+                         (FilePath, FilePath, FilePath -> Exp -> Spec)
+mkBeforeAfterTestCase name beforeDir afterDir = (before, after, specFun)
+  where before = beforeDir </> name <.> "grin"
+        after  = afterDir  </> name <.> "grin"
+        specFun after' transformed = do
+          expected <- runIO $ T.readFile after'
+          let expected' = parseProg expected
+          it name $ transformed `sameAs` expected'

--- a/grin/src/Transformations/ExtendedSyntax/Util.hs
+++ b/grin/src/Transformations/ExtendedSyntax/Util.hs
@@ -1,0 +1,282 @@
+{-# LANGUAGE LambdaCase, FlexibleContexts, RecordWildCards #-}
+module Transformations.ExtendedSyntax.Util where
+
+import Data.Map (Map)
+import qualified Data.Map as Map
+
+import Data.Maybe
+
+import Control.Monad
+import Control.Monad.State
+import Control.Monad.Trans.Except
+import Control.Comonad
+import Control.Comonad.Cofree
+import Data.Functor.Foldable as Foldable
+
+import Lens.Micro.Platform
+
+import Grin.ExtendedSyntax.Grin
+import Grin.ExtendedSyntax.Pretty
+import Grin.ExtendedSyntax.TypeEnvDefs
+
+{-
+  HINT: Name usage in Exp
+    - variable def
+        names in CPat
+        names in LPat
+        arg names in Def
+
+    - variable use
+        names in Val
+        names in FetchI and Update
+
+    - function binder
+        function name in Def
+
+    - function reference
+        function name in SApp
+-}
+
+foldNameUseExpF :: (Monoid m) => (Name -> m) -> ExpF a -> m
+foldNameUseExpF f = \case
+  ECaseF v _        -> f v
+  SAppF fun args    -> f fun <> foldMap f args
+  SReturnF val      -> foldNames f val
+  SStoreF v         -> f v
+  SUpdateF p v      -> f p <> f v
+  _                 -> mempty
+
+data DefRole = FunName | FunParam | BindVar | AltVar
+  deriving (Eq, Show)
+
+
+foldNameDefExpF :: (Monoid m) => (DefRole -> Name -> m) -> ExpF a -> m
+foldNameDefExpF f = \case
+  DefF name args _      -> mconcat $ (f FunName name) : map (f FunParam) args
+  EBindF _ bPat _       -> f BindVar (_bPatVar bPat)
+  AltF cpat _           -> foldNames (f AltVar) cpat
+  _                     -> mempty
+
+mapNamesCPat :: (Name -> Name) -> CPat -> CPat
+mapNamesCPat f = \case
+  NodePat tag args  -> NodePat tag (map f args)
+  cpat              -> cpat
+
+mapNamesVal :: (Name -> Name) -> Val -> Val
+mapNamesVal f = \case
+  ConstTagNode tag args -> ConstTagNode tag (map f args)
+  Var name              -> Var $ f name
+  val                   -> val
+
+mapNamesBPat :: (Name -> Name) -> BPat -> BPat
+mapNamesBPat f = \case
+  VarPat v      -> VarPat (f v)
+  AsPat var val -> AsPat (f var) (mapNamesVal f val)
+
+-- TODO: replace at use sites with
+-- mapValVal :: (Val -> Val) -> Val -> Val
+-- mapValVal f val = case f val of
+--   ConstTagNode tag vals -> ConstTagNode tag (map (mapValVal f) vals)
+--   VarTagNode name vals  -> VarTagNode name (map (mapValVal f) vals)
+--   val                   -> val
+
+mapValsExp :: (Val -> Val) -> Exp -> Exp
+mapValsExp f = \case
+  -- NOTE: does not recurse into alts
+  ECase scrut alts -> ECase scrut alts
+  SReturn val      -> SReturn $ f val
+  exp              -> exp
+
+mapValsExpM :: Monad m => (Val -> m Val) -> Exp -> m Exp
+mapValsExpM f = \case
+  SReturn val    -> SReturn <$> f val
+  exp            -> pure exp
+
+mapNameUseExp :: (Name -> Name) -> Exp -> Exp
+mapNameUseExp f = \case
+  SStore    v      -> SStore (f v)
+  SFetch  p        -> SFetch (f p)
+  SUpdate p v      -> SUpdate (f p) (f v)
+  -- NOTE: does not recurse into alts
+  ECase scrut alts -> ECase (f scrut) alts
+  SApp fun args    -> SApp (f fun) (map f args)
+  exp              -> mapValsExp (mapNamesVal f) exp
+
+subst :: Ord a => Map a a -> a -> a
+subst env x = Map.findWithDefault x x env
+
+-- variable reference substitution (non recursive)
+substVarRefExp :: Map Name Name -> Exp -> Exp
+substVarRefExp env = mapNameUseExp (subst env)
+
+-- val name substitution (non recursive)
+substNamesVal :: Map Name Name -> Val -> Val
+substNamesVal env = mapNamesVal (subst env)
+
+-- val name substitution (non recursive)
+substValsVal :: Map Val Val -> Val -> Val
+substValsVal env = subst env
+
+-- val substitution (non recursive)
+substVals :: Map Val Val -> Exp -> Exp
+substVals env = mapValsExp (subst env)
+
+cPatToVal :: CPat -> Val
+cPatToVal = \case
+  NodePat tag args  -> ConstTagNode tag args
+  LitPat  lit       -> Lit lit
+  DefaultPat        -> Unit
+
+cPatToAsPat :: Name -> CPat -> BPat
+cPatToAsPat name cPat = AsPat name (cPatToVal cPat)
+
+-- monadic recursion schemes
+--  see: https://jtobin.io/monadic-recursion-schemes
+
+cataM
+  :: (Monad m, Traversable (Base t), Recursive t)
+  => (Base t a -> m a) -> t ->  m a
+cataM alg = c where
+    c = alg <=< traverse c . project
+
+anaM
+  :: (Monad m, Traversable (Base t), Corecursive t)
+  => (a -> m (Base t a)) -> a -> m t
+anaM coalg = a where
+  a = (pure . embed) <=< traverse a <=< coalg
+
+paraM
+  :: (Monad m, Traversable (Base t), Recursive t)
+  => (Base t (t, a) -> m a) -> t -> m a
+paraM alg = p where
+  p   = alg <=< traverse f . project
+  f t = liftM2 (,) (pure t) (p t)
+
+apoM
+  :: (Monad m, Traversable (Base t), Corecursive t)
+  => (a -> m (Base t (Either t a))) -> a -> m t
+apoM coalg = a where
+  a = (pure . embed) <=< traverse f <=< coalg
+  f = either pure a
+
+hyloM
+  :: (Monad m, Traversable t)
+  => (t b -> m b) -> (a -> m (t a)) -> a -> m b
+hyloM alg coalg = h
+  where h = alg <=< traverse h <=< coalg
+
+histoM
+  :: (Monad m, Traversable (Base t), Recursive t)
+  => (Base t (Cofree (Base t) a) -> m a) -> t -> m a
+histoM h = pure . extract <=< worker where
+  worker = f <=< traverse worker . project
+  f x = (:<) <$> h x <*> pure x
+
+-- misc
+
+-- QUESTION: How should this be changed?
+skipUnit :: ExpF Exp -> Exp
+skipUnit = \case
+  -- EBindF (SReturn Unit) _ rightExp -> rightExp
+  exp -> embed exp
+
+newtype TagInfo = TagInfo { _tagArityMap :: Map.Map Tag Int }
+  deriving (Eq, Show)
+
+updateTagInfo :: Tag -> Int -> TagInfo -> TagInfo
+updateTagInfo t n ti@(TagInfo m) =
+  case Map.lookup t m of
+    Just arity | arity < n -> TagInfo $ Map.insert t n m
+    Nothing                -> TagInfo $ Map.insert t n m
+    _                      -> ti
+
+collectTagInfo :: Exp -> TagInfo
+collectTagInfo = flip execState (TagInfo Map.empty) . cataM alg
+  where
+    alg :: ExpF () -> State TagInfo ()
+    alg = \case
+      SReturnF val   -> goVal val
+      AltF cpat _    -> goCPat cpat
+      _              -> pure ()
+
+    goVal :: Val -> State TagInfo ()
+    goVal (ConstTagNode t args) = modify $ updateTagInfo t (length args)
+    goVal _ = pure ()
+
+    goCPat :: CPat -> State TagInfo ()
+    goCPat (NodePat t args) = modify $ updateTagInfo t (length args)
+    goCPat _ = pure ()
+
+lookupExcept :: (Monad m, Ord k) =>
+                String ->
+                k -> Map k v ->
+                ExceptT String m v
+lookupExcept err k = maybe (throwE err) pure . Map.lookup k
+
+lookupExceptT :: (MonadTrans t, Monad m, Ord k) =>
+                 String ->
+                 k -> Map k v ->
+                 t (ExceptT String m) v
+lookupExceptT err k = lift . lookupExcept err k
+
+mapWithDoubleKey :: (Ord k1, Ord k2) =>
+                    (k1 -> k2 -> a -> b) ->
+                    Map k1 (Map k2 a) ->
+                    Map k1 (Map k2 b)
+mapWithDoubleKey f = Map.mapWithKey (\k1 m -> Map.mapWithKey (f k1) m)
+
+mapWithDoubleKeyM :: (Ord k1, Ord k2, Monad m) =>
+                     (k1 -> k2 -> a -> m b) ->
+                     Map k1 (Map k2 a) ->
+                     m (Map k1 (Map k2 b))
+mapWithDoubleKeyM f = sequence . Map.mapWithKey (\k1 m -> sequence $ Map.mapWithKey (f k1) m)
+
+lookupWithDoubleKey :: (Ord k1, Ord k2) => k1 -> k2 -> Map k1 (Map k2 v) -> Maybe v
+lookupWithDoubleKey k1 k2 m = Map.lookup k1 m >>= Map.lookup k2
+
+lookupWithDoubleKeyExcept :: (Monad m, Ord k1, Ord k2) =>
+                             String -> k1 -> k2 ->
+                             Map k1 (Map k2 v) ->
+                             ExceptT String m v
+lookupWithDoubleKeyExcept err k1 k2 = maybe (throwE err) pure
+                                    . lookupWithDoubleKey k1 k2
+
+lookupWithDoubleKeyExceptT :: (MonadTrans t, Monad m, Ord k1, Ord k2) =>
+                              String -> k1 -> k2 ->
+                              Map k1 (Map k2 v) ->
+                              t (ExceptT String m) v
+lookupWithDoubleKeyExceptT err k1 k2 = lift . lookupWithDoubleKeyExcept err k1 k2
+
+
+notFoundIn :: Show a => String -> a -> String -> String
+notFoundIn n1 x n2 = n1 ++ " " ++ show x ++ " not found in " ++ n2
+
+markToRemove :: a -> Bool -> Maybe a
+markToRemove x True  = Just x
+markToRemove _ False = Nothing
+
+zipFilter :: [a] -> [Bool] -> [a]
+zipFilter xs = catMaybes . zipWith markToRemove xs
+
+bindToUndefineds :: Monad m => TypeEnv -> Exp -> [Name] -> ExceptT String m Exp
+bindToUndefineds TypeEnv{..} = foldM bindToUndefined where
+
+  bindToUndefined :: Monad m => Exp -> Name -> ExceptT String m Exp
+  bindToUndefined rhs v = do
+    ty <- lookupExcept (notInTypeEnv v) v _variable
+    let ty' = simplifyType ty
+    pure $ EBind (SReturn (Undefined ty')) (VarPat v) rhs
+
+  notInTypeEnv v = "Variable " ++ show (PP v) ++ " was not found in the type environment."
+
+
+simplifySimpleType :: SimpleType -> SimpleType
+simplifySimpleType (T_Location _) = T_UnspecifiedLocation
+simplifySimpleType t = t
+
+simplifyNodeSet :: NodeSet -> NodeSet
+simplifyNodeSet = fmap (fmap simplifySimpleType)
+
+simplifyType :: Type -> Type
+simplifyType (T_SimpleType st) = T_SimpleType $ simplifySimpleType st
+simplifyType (T_NodeSet    ns) = T_NodeSet $ simplifyNodeSet ns

--- a/grin/test/AbstractInterpretation/ExtendedSyntax/HptSpec.hs
+++ b/grin/test/AbstractInterpretation/ExtendedSyntax/HptSpec.hs
@@ -44,7 +44,35 @@ spec = do
             }
       result `shouldBe` exptected
 
-    it "handles as-patterns correctly" $ do
+    it "handles as-patterns with variables correctly" $ do
+      let code = withPrimPrelude [prog|
+            grinMain =
+              k0 <- pure 0
+              x0 <- pure (CInt k0)
+              x1@x2 <- pure x0
+
+              pure ()
+          |]
+      let result = inferTypeEnv code
+          exptected = emptyTypeEnv
+            { TypeEnv._variable = Map.fromList
+                [ ("k0",   int64_t)
+                -- , ("k1",   int64_t)
+                -- , ("k2",   int64_t)
+                -- , ("_v",   unit_t)
+                , ("x0",   T_NodeSet $ cnode_t "Int" [TypeEnv.T_Int64])
+                , ("x1",   T_NodeSet $ cnode_t "Int" [TypeEnv.T_Int64])
+                , ("x2",   T_NodeSet $ cnode_t "Int" [TypeEnv.T_Int64])
+                ]
+            , TypeEnv._function = mconcat
+                [ fun_t "grinMain" [] unit_t
+                -- , fun_t "_prim_int_add" [int64_t, int64_t] int64_t
+                -- , fun_t "_prim_int_print" [int64_t] unit_t
+                ]
+            }
+      result `shouldBe` exptected
+
+    it "handles as-patterns with nodes correctly" $ do
       let code = withPrimPrelude [prog|
             grinMain =
               k0 <- pure 0

--- a/grin/test/AbstractInterpretation/ExtendedSyntax/HptSpec.hs
+++ b/grin/test/AbstractInterpretation/ExtendedSyntax/HptSpec.hs
@@ -1,0 +1,190 @@
+{-# LANGUAGE LambdaCase, QuasiQuotes, OverloadedStrings #-}
+module AbstractInterpretation.ExtendedSyntax.HptSpec where
+
+import Test.Hspec
+import Test.ExtendedSyntax.Util
+import Grin.ExtendedSyntax.Grin
+import Grin.ExtendedSyntax.TH
+import Grin.ExtendedSyntax.Lint
+import Grin.ExtendedSyntax.TypeEnv as TypeEnv
+import Grin.ExtendedSyntax.TypeCheck
+import Grin.ExtendedSyntax.PrimOpsPrelude
+
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified Data.Vector as V
+
+import AbstractInterpretation.ExtendedSyntax.HeapPointsTo.Result as HPT
+import AbstractInterpretation.ExtendedSyntax.Reduce (evalAbstractProgram, _airComp)
+import AbstractInterpretation.ExtendedSyntax.HeapPointsTo.CodeGen (codeGen)
+
+runTests :: IO ()
+runTests = hspec spec
+
+spec :: Spec
+spec = do
+  describe "HPT" $ do
+    it "calculates nondefined functions" $ do
+      let code = [prog|
+        grinMain =
+          a <- pure 1
+          b <- nondeffun a
+          pure ()
+        |]
+      let result = inferTypeEnv code
+      let exptected = emptyTypeEnv
+            { _variable = Map.fromList
+                [ ("a", int64_t)
+                , ("b", dead_t)
+                ]
+            , TypeEnv._function = mconcat
+                [ fun_t "grinMain" [] unit_t
+                , fun_t "nondeffun" [int64_t] dead_t
+                ]
+            }
+      result `shouldBe` exptected
+
+  describe "case" $ do
+    it "default bug01" $ do
+      let code = withPrimPrelude [prog|
+        grinMain =
+          n <- pure 1
+          m <- pure 2
+          _v@(CInt x) <- test n m
+          y <- pure x
+          _prim_int_print y
+
+        test a b =
+          c <- _prim_int_add a b
+          case c of
+                0 ->
+                  k <- pure 100
+                  pure (CInt k)
+                1 ->
+                  e0 <- pure c
+                  pure (CInt e0)
+                #default ->
+                  e1 <- pure c
+                  pure (CInt e1)
+        |]
+      let result = inferTypeEnv code
+          exptected = emptyTypeEnv
+            { TypeEnv._variable = Map.fromList
+                [ ("a",   int64_t)
+                , ("b",   int64_t)
+                , ("c",   int64_t)
+                , ("e0",  int64_t)
+                , ("e1",  int64_t)
+                , ("x",   int64_t)
+                , ("y",   int64_t)
+                , ("n",   int64_t)
+                , ("m",   int64_t)
+                , ("k",   int64_t)
+                , ("_v",  T_NodeSet $ cnode_t "Int" [TypeEnv.T_Int64])
+                ]
+            , TypeEnv._function = mconcat
+                [ fun_t "_prim_int_add" [int64_t, int64_t] int64_t
+                , fun_t "_prim_int_print" [int64_t] unit_t
+                , fun_t "grinMain" [] unit_t
+                , fun_t "test" [int64_t, int64_t] $ T_NodeSet $ cnode_t "Int" [TypeEnv.T_Int64]
+                ]
+            }
+      result `shouldBe` exptected
+
+  let loc = tySetFromTypes . pure . HPT.T_Location
+      mkNode = V.fromList . map Set.fromList
+      mkNodeSet = NodeSet . Map.fromList . map (\(t,v) -> (t,mkNode v))
+      tySetFromNodes = TypeSet mempty
+      mkTySet = tySetFromNodes . mkNodeSet
+      tySetFromTypes = flip TypeSet mempty . Set.fromList
+      mkSimpleMain t = (tySetFromTypes [t], mempty)
+
+  describe "HPT Result" $ do
+    it "undefined" $ do
+      let exp = [prog|
+            grinMain =
+              nil <- pure (CNil)
+              p0 <- store nil
+              k0 <- pure 0
+              cons <- pure (CCons k0 p0)
+              p1 <- store cons
+              x0 <- pure (#undefined :: T_Int64)
+              n0 <- pure (#undefined :: {CCons[T_Int64,{0,1}]})
+              p2 <- store n0
+              n1 <- pure (#undefined :: {CNil[],CCons[T_Int64,{2}]})
+              x1 <- pure (#undefined :: T_Int64)
+              n2 <- pure (CCons x1 p0)
+              pure 5
+          |]
+      let expected = HPTResult
+            { HPT._memory   = undefinedExpectedHeap
+            , HPT._register = undefinedExpectedRegisters
+            , HPT._function = Map.singleton "grinMain" (mkSimpleMain HPT.T_Int64)
+            }
+          nodeSetN0 = mkNodeSet [(cCons, [[HPT.T_Int64], [HPT.T_Location 0, HPT.T_Location 1]])]
+          undefinedExpectedHeap = V.fromList
+            [ nilTy
+            , consTy
+            , nodeSetN0
+            ]
+          undefinedExpectedRegisters = Map.fromList
+            [ ("p0",   loc 0)
+            , ("p1",   loc 1)
+            , ("p2",   loc 2)
+            , ("nil",  tySetFromNodes nilTy)
+            , ("cons", tySetFromNodes consTy)
+            , ("x0",   tySetFromTypes [HPT.T_Int64])
+            , ("x1",   tySetFromTypes [HPT.T_Int64])
+            , ("n0",   TypeSet mempty nodeSetN0)
+            , ("n1",   typeN1)
+            , ("n2",   typeN2)
+            , ("k0",   tySetFromTypes [HPT.T_Int64])
+            ]
+          typeN1 = mkTySet [ (cCons, [[HPT.T_Int64], [HPT.T_Location 2]]) , (cNil, []) ]
+          typeN2 = mkTySet [ (cCons, [[HPT.T_Int64], [HPT.T_Location 0]]) ]
+          nilTy  = mkNodeSet [(cNil, [])]
+          consTy = mkNodeSet [(cCons, [[HPT.T_Int64], [HPT.T_Location 0]])]
+
+      (calcHPTResult exp) `shouldBe` expected
+
+    it "unspec_loc" $ do
+      let exp = [prog|
+            grinMain =
+              k0 <- pure 0
+              p0 <- case k0 of
+                0 ->
+                  nil <- pure (CNil)
+                  store nil
+                1 ->
+                  pure (#undefined :: #ptr)
+              n0 <- fetch p0
+              n1 <- pure (#undefined :: {CNode[#ptr]})
+              _v@(CNode p1) <- pure n1
+              x0 <- fetch p1
+              update p0 x0
+          |]
+      let expected = HPTResult
+            { HPT._memory   = V.fromList [ nodeSetN0 ]
+            , HPT._register = unspecLocExpectedRegisters
+            , HPT._function = Map.singleton "grinMain" (mkSimpleMain HPT.T_Unit)
+            }
+          nodeSetN0 = mkNodeSet [(cNil,  [])]
+          nodeSetN1 = mkNodeSet [(cNode, [[HPT.T_UnspecifiedLocation]])]
+
+          unspecLocExpectedRegisters = Map.fromList
+            [ ("k0", tySetFromTypes [HPT.T_Int64])
+            , ("p0", tySetFromTypes [HPT.T_Location 0, HPT.T_UnspecifiedLocation])
+            , ("p1", tySetFromTypes [HPT.T_UnspecifiedLocation])
+            , ("n0", tySetFromNodes nodeSetN0)
+            , ("n1", tySetFromNodes nodeSetN1)
+            , ("_v", tySetFromNodes nodeSetN1)
+            , ("x0", tySetFromTypes [])
+            , ("nil", tySetFromNodes nodeSetN0)
+            ]
+      (calcHPTResult exp) `shouldBe` expected
+
+calcHPTResult :: Exp -> HPTResult
+calcHPTResult prog
+  | (hptProgram, hptMapping) <- codeGen prog
+  , computer <- _airComp . evalAbstractProgram $ hptProgram
+  = toHPTResult hptMapping computer

--- a/grin/test/ExtendedSyntax/LintSpec.hs
+++ b/grin/test/ExtendedSyntax/LintSpec.hs
@@ -1,0 +1,362 @@
+{-# LANGUAGE OverloadedStrings, QuasiQuotes, ViewPatterns #-}
+module ExtendedSyntax.LintSpec where
+
+import qualified Data.Map as Map
+
+import Test.Hspec
+
+import Grin.ExtendedSyntax.Grin
+import Grin.ExtendedSyntax.TH
+import Grin.ExtendedSyntax.Lint
+import Grin.ExtendedSyntax.TypeEnv
+import Grin.ExtendedSyntax.TypeCheck (inferTypeEnv)
+import Grin.ExtendedSyntax.PrimOpsPrelude
+
+
+runTests :: IO ()
+runTests = hspec spec
+
+lintErrors :: Map.Map Int [Error] -> [String]
+lintErrors = map message . concat . Map.elems
+
+spec :: Spec
+spec = do
+
+  describe "Variable lint" $ do
+    -- TODO: withPrimPrelude
+    it "finds undefined variables" $ do
+      let program = withPrimPrelude [prog|
+        undefinedParam p1 p2 =
+          _prim_int_print p3
+        |]
+      let (_, errors) = lint allWarnings Nothing program
+      lintErrors errors `shouldBe` ["undefined variable: p3"]
+
+  describe "Function call lint" $ do
+    it "finds variable used as a function" $ do
+      let program = [prog|
+          name1 p11 p12 =
+            a1 <- name0 p11 p12
+            pure a1
+
+          name0 p01 p02 =
+            b0 <- p11 p01 p02
+            pure b0
+        |]
+      let (_, errors) = lint allWarnings Nothing program
+      lintErrors errors `shouldBe` ["non-function in function call: p11"]
+
+    it "finds non-saturated function calls" $ do
+      let program = withPrimPrelude [prog|
+          fun1 p1 p2 =
+            _prim_int_add p1 p2
+
+          fun2 =
+            p3 <- fun1 3
+            pure p3
+        |]
+      let (_, errors) = lint allWarnings Nothing program
+      lintErrors errors `shouldBe` ["non-saturated function call: fun1"]
+
+  describe "Case lint" $ do
+    it "finds location used as matched value" $ do
+      let program = [prog|
+          main =
+            n <- pure (CInt 3)
+            l <- store n
+            case l of
+              3 -> pure ()
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_,errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["case variable l has non-supported pattern match type: {0}"]
+
+    it "finds string used as matched value" $ do
+      let program = [prog|
+          main =
+            s <- pure #"string"
+            case s of
+              #"string" -> pure ()
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_,errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["case variable s has non-supported pattern match type: T_String"]
+
+    it "finds string used as matched value" $ do
+      let program = [prog|
+          main =
+            f <- pure 1.0
+            case f of
+              1.0 -> pure ()
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_,errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["case variable f has non-supported pattern match type: T_Float"]
+
+    it "finds overlapping node alternatives" $ do
+      let program = [prog|
+          main =
+            x <- pure (CInt 1)
+            case x of
+              (CInt a)   -> pure ()
+              (CFloat b) -> pure ()
+              (CInt c)   -> pure ()
+        |]
+      let (_,errors) = lint allWarnings Nothing program
+      lintErrors errors `shouldBe` ["case has overlapping node alternatives CInt"]
+
+    it "finds overlapping literal alternatives" $ do
+      let program = [prog|
+          main =
+            x <- pure 1
+            case x of
+              1 -> pure ()
+              2 -> pure ()
+              1 -> pure ()
+        |]
+      let (_,errors) = lint allWarnings Nothing program
+      lintErrors errors `shouldBe` ["case has overlapping literal alternatives 1"]
+
+    it "finds non-covered node alternatives" $ do
+      let program = [prog|
+          main =
+            n0 <- pure (CInt 1)
+            n1 <- pure (CFloat 1)
+            n2 <- pure (CBool #True)
+            l <- store n0
+            update l n1
+            update l n2
+            v <- fetch l
+            case v of
+              (CInt a) -> pure ()
+              (CFloat b) -> pure ()
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_,errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["case has non-covered alternative CBool"]
+
+    it "does not report non-covered nodes with default branch" $ do
+      let program = [prog|
+          main =
+            n0 <- pure (CInt 1)
+            n1 <- pure (CFloat 1)
+            n2 <- pure (CBool #True)
+            l <- store n0
+            update l n1
+            update l n2
+            v <- fetch l
+            case v of
+              (CInt a) -> pure ()
+              (CFloat b) -> pure ()
+              #default -> pure ()
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_,errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` []
+
+    it "finds duplicate default alternatives" $ do
+      let program = [prog|
+            main =
+              case 3 of
+                #default -> pure ()
+                3 -> pure ()
+                #default -> pure ()
+          |]
+      let (_,errors) = lint allWarnings Nothing program
+      lintErrors errors `shouldBe` ["case has more than one default alternatives"]
+
+  describe "Store lint" $ do
+    it "finds primitive value as argument." $ do
+      let program = [prog|
+          main =
+            v <- pure 1
+            l <- store v
+            pure ()
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_,errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["store has given a primitive value: v :: T_Int64"]
+
+  describe "Fetch lint" $ do
+    it "finds non-location value as parameter" $ do
+      let program = [prog|
+          main =
+            l <- pure 1
+            x <- fetch l
+            pure ()
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_,errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["the parameter of fetch is a primitive type: l :: T_Int64"]
+
+  describe "Update lint" $ do
+    it "finds non-location value as parameter" $ do
+      let program = [prog|
+          main =
+            l <- pure 1
+            n <- pure (CInt 1)
+            x <- update l n
+            pure ()
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_,errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["the parameter of update is a primitive type: l :: T_Int64"]
+
+    it "finds primitive value as argument." $ do
+      let program = [prog|
+          main =
+            n <- pure (CInt 1)
+            l <- store n
+            v <- pure 2
+            x <- update l v
+            pure ()
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_,errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["update has given a primitive value: v :: T_Int64"]
+
+  describe "Bind lint" $ do
+    it "find ill-matching patterns" $ do
+      let program = [prog|
+          main =
+            n <- pure (CFloat 2.0)
+            (CInt x) <- pure n
+            pure ()
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_, errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["Invalid pattern match for (CInt x). Expected pattern of type: {CInt[T_Dead]}, but got: {CFloat[T_Float]}"]
+
+    it "disregards variable patterns" $ do
+      let program = [prog|
+          main =
+            n0 <- pure (CInt 0)
+            n1 <- case n0 of
+              (CInt c0) -> pure n0
+              (CFloat c1) ->
+                a0 <- pure (CFloat 2.0)
+                pure a0
+            pure ()
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_, errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` []
+
+    -- NOTE: Bottom-up typing can only approximate the result of HPT.
+    it "can give false positive errors" $ do
+      let program = [prog|
+          main =
+            n0 <- case 0 of
+              0 ->
+                n1 <- pure (CInt 0)
+                pure n1
+              1 ->
+                n2 <- pure (CFloat 0.0)
+                pure n2
+            (CInt x) <- case n0 of
+              (CInt c0) -> pure n0
+              (CFloat c1) ->
+                a0 <- pure (CInt 0)
+                pure a0
+            pure ()
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_, errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["Invalid pattern match for (CInt x). Expected pattern of type: {CInt[T_Int64]}, but got: {CFloat[T_Float],CInt[T_Int64]}"]
+
+  describe "Producer lint" $ do
+    it "finds nodes in single return statment" $ do
+      let program = [prog|
+          grinMain =
+            pure (CInt 5)
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_, errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["Last return expressions can only return non-node values: pure (CInt 5)"]
+
+    it "finds nodes in last return statment" $ do
+      let program = [prog|
+          grinMain =
+            n <- pure (CInt 0)
+            pure (CInt 5)
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_, errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["Last return expressions can only return non-node values: pure (CInt 5)"]
+
+    it "finds nodes in single return statment in case alternative" $ do
+      let program = [prog|
+          grinMain =
+            case 0 of
+              0 -> pure (CInt 5)
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_, errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["Last return expressions can only return non-node values: pure (CInt 5)"]
+
+    it "finds nodes in last return statment in case alternative" $ do
+      let program = [prog|
+          grinMain =
+            case 0 of
+              0 ->
+                n <- pure 0
+                pure (CInt 5)
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_, errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["Last return expressions can only return non-node values: pure (CInt 5)"]
+
+    it "allows nodes as patterns for bindings" $ do
+      let program = [prog|
+          grinMain =
+            n <- pure (CInt 5)
+            (CInt 5) <- pure n
+            pure 0
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_, errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` []
+
+    it "finds expressions with nodes bound to non-variable patterns" $ do
+      let program = [prog|
+          grinMain =
+            (CInt 5) <- pure (CInt 5)
+            pure 0
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_, errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["Syntax error - expected SimpleExp without nodes"]
+
+    it "finds nodes in Stores" $ do
+      let program = [prog|
+          grinMain =
+            p <- store (CInt 5)
+            pure 0
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_, errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["Syntax error - expected SimpleVal"]
+
+    it "finds nodes in updates" $ do
+      let program = [prog|
+          grinMain =
+            n <- pure (CInt 5)
+            p <- store n
+            update p (CInt 0)
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_, errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["Syntax error - expected SimpleVal"]
+
+    -- this is optional, but makes DDE simpler
+    it "finds nodes LPat of a binding with a Fetch left-hand side" $ do
+      let program = [prog|
+          grinMain =
+            n <- pure (CInt 5)
+            p <- store n
+            (CInt 5) <- fetch p
+            pure 0
+        |]
+      let typeEnv = inferTypeEnv program
+      let (_, errors) = lint allWarnings (Just typeEnv) program
+      lintErrors errors `shouldBe` ["The result of Fetch can only be bound to a variable: (CInt 5)"]

--- a/grin/test/ExtendedSyntax/ParserSpec.hs
+++ b/grin/test/ExtendedSyntax/ParserSpec.hs
@@ -9,6 +9,7 @@ import Grin.ExtendedSyntax.Pretty
 import Grin.ExtendedSyntax.Grin
 import Grin.ExtendedSyntax.TH
 import Grin.ExtendedSyntax.Parse
+import Grin.ExtendedSyntax.PrimOpsPrelude
 
 import Test.ExtendedSyntax.Old.Test
 import Test.ExtendedSyntax.Assertions
@@ -335,9 +336,14 @@ spec = do
             EBind (SReturn $ Var "v2") (AsPat "_c" $ Lit (LChar 'a')) $
             SReturn Unit
           ]
-    before `shouldBe` after
+    before `sameAs` after
 
   describe "external defintions" $ do
+    it "primops-prelude" $ do
+      let before = withPrimPrelude $ Program [] []
+      let after  = primPrelude
+      before `shouldBe` after
+
     it "primop" $ do
       let before = [prog|
         primop effectful


### PR DESCRIPTION
Modified HPT and the linter such that they correctly handle the new syntax.

- [x] type checker
- [x] linter
- [x] HPT
- [x] linter tests
- [x] HPT tests
- [x] Add more tests to HPT (for new syntax) 
- [ ] Possibly add tests for type checker (?)

For more details see #32. 