### PR TITLE
Eval statistics.

### DIFF
--- a/grin/app/CLI/Lib.hs
+++ b/grin/app/CLI/Lib.hs
@@ -121,7 +121,8 @@ pipelineOpts =
   <|> flg (Pass [Sharing Compile, Sharing Optimise, Sharing RunPure]) "sharing-opt" "Compiles, optimizes and runs the sharing analysis"
   <|> flg  (Pass [LVA Compile, CBy Compile, RunCByWithLVA]) "cby-with-lva" "Compiles the live variable and created-by analyses, then runs the created-by analysis using the LVA result"
   <|> flg DeadCodeElimination "dce" "Dead Code Elimination"
-  <|> flg PureEval "eval" "Evaluate the grin program (pure)"
+  <|> flg (PureEval False) "eval" "Evaluate the grin program (pure)"
+  <|> (PureEval <$> (option auto (mconcat [long "eval-with-statistics", help "Evaluate the grin program (pure) and render heap statistics."])))
   <|> flg JITLLVM "llvm" "JIT with LLVM"
   <|> flg PrintAST "ast" "Print the Abstract Syntax Tree"
   <|> (SaveExecutable False . Abs <$> (strOption (mconcat [short 'o', long "save-elf", help "Save an executable ELF"])))

--- a/grin/src/Pipeline/Eval.hs
+++ b/grin/src/Pipeline/Eval.hs
@@ -7,7 +7,7 @@ import Text.Megaparsec
 import Grin.Grin
 import Grin.TypeCheck
 import Grin.Parse
-import Reducer.Base (RTVal)
+import Reducer.Base (RTVal, Statistics)
 import qualified Reducer.IO
 import qualified Reducer.Pure
 import qualified Reducer.LLVM.JIT as LLVM
@@ -22,7 +22,7 @@ data Reducer
   = PureReducer Reducer.Pure.EvalPlugin
   | IOReducer
 
-evalProgram :: Reducer -> Program -> IO RTVal
+evalProgram :: Reducer -> Program -> IO (RTVal, Maybe Statistics)
 evalProgram reducer program =
   case reducer of
     PureReducer evalPrimOp  -> Reducer.Pure.reduceFun evalPrimOp program "grinMain"

--- a/grin/src/Reducer/Base.hs
+++ b/grin/src/Reducer/Base.hs
@@ -1,13 +1,15 @@
 {-# LANGUAGE LambdaCase, TupleSections, BangPatterns #-}
 module Reducer.Base where
 
+import Data.IntMap.Strict (IntMap)
 import Data.Map (Map)
-import qualified Data.Map as Map
-
-import Text.PrettyPrint.ANSI.Leijen
-
 import Grin.Grin
 import Grin.Pretty
+import Text.PrettyPrint.ANSI.Leijen
+
+import qualified Data.Map as Map
+import qualified Data.IntMap.Strict as IntMap
+
 
 -- models cpu registers
 type Env = Map Name RTVal
@@ -34,6 +36,23 @@ instance Pretty RTVal where
     RT_Var name   -> pretty name
     RT_Loc a      -> keyword "loc" <+> int a
     RT_Undefined  -> keyword "undefined"
+
+data Statistics
+  = Statistics
+  { storeFetched :: !(IntMap Int)
+  , storeUpdated :: !(IntMap Int)
+  }
+
+emptyStatistics = Statistics mempty mempty
+
+instance Pretty Statistics where
+  pretty (Statistics f u) =
+    vsep
+      [ text "Fetched:"
+      , indent 4 $ prettyKeyValue $ IntMap.toList $ IntMap.filter (>0) f
+      , text "Updated:"
+      , indent 4 $ prettyKeyValue $ IntMap.toList $ IntMap.filter (>0) u
+      ]
 
 keyword :: String -> Doc
 keyword = yellow . text

--- a/grin/src/Reducer/IO.hs
+++ b/grin/src/Reducer/IO.hs
@@ -116,11 +116,11 @@ evalSimpleExp exts env = \case
   SBlock a -> evalExp exts env a
   x -> error $ "evalSimpleExp: " ++ show x
 
-reduceFun :: Program -> Name -> IO RTVal
+reduceFun :: Program -> Name -> IO (RTVal, Maybe Statistics)
 reduceFun (Program exts l) n = do
   store <- emptyStore1
   (val, _, _) <- runRWST (evalExp exts mempty e) m store
-  pure val
+  pure (val, Nothing)
   where
     m = Map.fromList [(n,d) | d@(Def n _ _) <- l]
     e = case Map.lookup n m of


### PR DESCRIPTION
This is a preliminary for the counting immutable beans implementation.

Motivation: The CIB runtime reuses heap locations after instrumentation of the code. I am going to implement such an evaluator but before that I would like to measure the heap access patterns for the Idris compiled programs. Thus I need this piece of functionality first.