### PR TITLE
Fix set1 parsing and ignore HIE yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ grin/.end-to-end-test/
 *.out.ll
 *.out.s
 .ghc.environment.*
+hie.yaml
+*.lock

--- a/grin/src/Grin/ExtendedSyntax/Parse/Basic.hs
+++ b/grin/src/Grin/ExtendedSyntax/Parse/Basic.hs
@@ -89,11 +89,14 @@ vec1 p = Vec.fromList <$> list1 p
 bracedList :: Parser a -> Parser [a]
 bracedList p = braces (sepBy p (op ","))
 
+bracedList1 :: Parser a -> Parser [a]
+bracedList1 p = braces (sepBy1 p (op ","))
+
 set :: Ord a => Parser a -> Parser (Set a)
 set p = Set.fromList <$> bracedList p
 
 set1 :: Ord a => Parser a -> Parser (Set a)
-set1 p = Set.fromList <$> bracedList p
+set1 p = Set.fromList <$> bracedList1 p
 
 anySingleBut :: MonadParsec e s m => Token s -> m (Token s)
 anySingleBut t = satisfy (/= t)


### PR DESCRIPTION
The previous `set1` parser would have been able to parse an empty set because it uses `sepBy` instead of `sepBy1`.

It doesn't seem to be used for anything but I think it could be an issue later.

The ignore HIE Yaml is in case anyone uses the Haskell IDE Engine.