### PR TITLE
Don't arity raise or unbox `grinMain`

### DIFF
--- a/grin/src/Transformations/Optimising/ArityRaising.hs
+++ b/grin/src/Transformations/Optimising/ArityRaising.hs
@@ -103,6 +103,7 @@ phase1 te = pdArityData . cata collect where
             , isJust mtag
             , p `notElem` (bdOther body)
             , p `notElem` (snd <$> (filter ((/=fn) . fst) (bdFunCall body)))
+            , fn /= "grinMain"
             ]
       in FunData $ case funData of
           [] -> Map.empty

--- a/grin/src/Transformations/Optimising/GeneralizedUnboxing.hs
+++ b/grin/src/Transformations/Optimising/GeneralizedUnboxing.hs
@@ -92,7 +92,7 @@ functionsToUnbox te (Program exts defs) = result where
 
   nonCandidateTailCallMap = Map.withoutKeys tranisitiveTailCalls result0
   candidateCalledByNonCandidate = (Set.unions $ Map.elems nonCandidateTailCallMap) `Set.intersection` result0
-  result = result0 `Set.difference` candidateCalledByNonCandidate
+  result = Set.delete "grinMain" $ result0 `Set.difference` candidateCalledByNonCandidate
 
   result0 = Set.fromList $ step initial
   initial = map funName $ filter (doesReturnAKnownProduct te . funName) defs


### PR DESCRIPTION
`grinMain` never has arguments so this makes no difference and these transforms mess with the name, so other optimisations (eg SimpleDeadFunctionElimination) don't work.