### PR TITLE
Allow specifying the library an ffi function comes from

### DIFF
--- a/grin/src/Grin/ExtendedSyntax/Nametable.hs
+++ b/grin/src/Grin/ExtendedSyntax/Nametable.hs
@@ -74,8 +74,9 @@ external (External{..}) =
   External <$> nameToIdx eName
            <*> ty eRetType
            <*> mapM ty eArgsType
-           <*> (pure eEffectful)
-           <*> (pure eKind)
+           <*> pure eEffectful
+           <*> pure eKind
+           <*> pure eLibs
 
 -- | Convert Names in the expression to Int identifiers and create
 -- an associated name table.
@@ -147,6 +148,7 @@ restore (exp, nt) = cata build exp where
              (map rty eArgsType)
              eEffectful
              eKind
+             eLibs
 
   rty :: Ty -> Ty
   rty = \case

--- a/grin/src/Grin/ExtendedSyntax/Parse/AST.hs
+++ b/grin/src/Grin/ExtendedSyntax/Parse/AST.hs
@@ -89,15 +89,41 @@ satisfyM pred parser = do
 
 -- externals
 
+externalBlock :: Parser [External]
 externalBlock = do
   L.indentGuard sc EQ pos1
   ext <- const PrimOp <$> kw "primop" <|> const FFI <$> kw "ffi"
   eff <- const False <$> kw "pure" <|> const True <$> kw "effectful"
   i <- L.indentGuard sc GT pos1
-  some $ try (external ext eff i)
+  libs <- externalLibs i
+  some $ try (external ext eff i libs)
 
-external :: ExternalKind -> Bool -> Pos -> Parser External
-external ext eff i = do
+externOS :: Parser OS
+externOS = choice
+  [ Darwin <$ kw "darwin"
+  , FreeBSD <$ kw "freebsd"
+  , Linux <$ kw "linux"
+  , Android <$ kw "android"
+  , MinGW <$ kw "mingw"
+  , Win <$ kw "win"
+  , NetBSD <$ kw "netbsd"
+  , OpenBSD <$ kw "openbsd"
+  ]
+
+externalLibs :: Pos -> Parser [(OS, Text)]
+externalLibs i =
+  many
+    $ L.indentGuard sc EQ i
+    *> L.lexeme sc
+      ((,)
+      <$> externOS
+      <*> between
+        (char '"')
+        (char '"')
+        (takeWhile1P (Just "library") (/= '"')))
+
+external :: ExternalKind -> Bool -> Pos -> [(OS, Text)] -> Parser External
+external ext eff i libs = do
   L.indentGuard sc EQ i
   name <- var
   L.indentGuard sc GT i >> op "::"
@@ -109,6 +135,7 @@ external ext eff i = do
     , eArgsType   = reverse argTyRev
     , eEffectful  = eff
     , eKind       = ext
+    , eLibs       = libs
     }
 
 tyP :: Parser Ty

--- a/grin/src/Grin/ExtendedSyntax/Syntax.hs
+++ b/grin/src/Grin/ExtendedSyntax/Syntax.hs
@@ -35,6 +35,9 @@ data ExternalKind
   | FFI    -- ^ Implemented in C and linked during the linker phase
   deriving (Generic, Data, NFData, Binary, Eq, Ord, Show)
 
+data OS = Darwin | FreeBSD | Linux | Android | MinGW | Win | NetBSD | OpenBSD
+  deriving (Generic, Data, NFData, Binary, Eq, Ord, Show)
+
 data External
   = External
   { eName       :: Name
@@ -42,6 +45,7 @@ data External
   , eArgsType   :: [Ty]
   , eEffectful  :: Bool
   , eKind       :: ExternalKind
+  , eLibs       :: [(OS, Text)]
   }
   deriving (Generic, Data, NFData, Binary, Eq, Ord, Show)
 

--- a/grin/src/Grin/Nametable.hs
+++ b/grin/src/Grin/Nametable.hs
@@ -77,8 +77,9 @@ external (External{..}) =
   External <$> nameToIdx eName
            <*> ty eRetType
            <*> mapM ty eArgsType
-           <*> (pure eEffectful)
-           <*> (pure eKind)
+           <*> pure eEffectful
+           <*> pure eKind
+           <*> pure eLibs
 
 -- | Convert Names in the expression to Int identifiers and create
 -- an associated name table.
@@ -151,6 +152,7 @@ restore (exp, nt) = cata build exp where
              (map rty eArgsType)
              eEffectful
              eKind
+             eLibs
 
   rty :: Ty -> Ty
   rty = \case

--- a/grin/src/Grin/Syntax.hs
+++ b/grin/src/Grin/Syntax.hs
@@ -37,6 +37,9 @@ data ExternalKind
   | FFI    -- ^ Implemented in C and linked during the linker phase
   deriving (Generic, Data, NFData, Eq, Ord, Show)
 
+data OS = Darwin | FreeBSD | Linux | Android | MinGW | Win | NetBSD | OpenBSD
+  deriving (Generic, Data, NFData, Eq, Ord, Show)
+
 data External
   = External
   { eName       :: Name
@@ -44,6 +47,7 @@ data External
   , eArgsType   :: [Ty]
   , eEffectful  :: Bool
   , eKind       :: ExternalKind
+  , eLibs       :: [(OS, Text)]
   }
   deriving (Generic, Data, NFData, Eq, Ord, Show)
 
@@ -124,6 +128,7 @@ externals = \case
 
 deriving instance Binary Name
 deriving instance Binary ExternalKind
+deriving instance Binary OS
 deriving instance Binary External
 deriving instance Binary Ty
 deriving instance Binary SimpleType

--- a/grin/src/Transformations/ExtendedSyntax/Conversion.hs
+++ b/grin/src/Transformations/ExtendedSyntax/Conversion.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -38,6 +39,16 @@ import Transformations.Simplifying.BindingPatternSimplification
 
 class Convertible a b where
   convert :: a -> b
+
+instance Convertible a b => Convertible [a] [b] where
+  convert [] = []
+  convert (x : xs) = convert x : convert xs
+
+instance Convertible a a where
+  convert = id
+
+instance (Convertible a c, Convertible b d) => Convertible (a, b) (c, d) where
+  convert (x, y) = (convert x, convert y)
 
 instance Convertible TagType New.TagType where
   convert = \case
@@ -95,6 +106,17 @@ instance Convertible ExternalKind New.ExternalKind where
     PrimOp -> New.PrimOp
     FFI    -> New.FFI
 
+instance Convertible OS New.OS where
+    convert = \case
+      Darwin -> New.Darwin
+      FreeBSD -> New.FreeBSD
+      Linux -> New.Linux
+      Android -> New.Android
+      MinGW -> New.MinGW
+      Win -> New.Win
+      NetBSD -> New.NetBSD
+      OpenBSD -> New.OpenBSD
+
 instance Convertible External New.External where
   convert External{..} = New.External
     (convert eName)
@@ -102,6 +124,7 @@ instance Convertible External New.External where
     (map convert eArgsType)
     eEffectful
     (convert eKind)
+    (convert eLibs)
 
 instance Convertible CPat New.CPat where
   convert = \case
@@ -286,6 +309,17 @@ instance Convertible New.ExternalKind ExternalKind where
     New.PrimOp -> PrimOp
     New.FFI    -> FFI
 
+instance Convertible New.OS OS where
+  convert = \case
+    New.Darwin  -> Darwin
+    New.FreeBSD -> FreeBSD
+    New.Linux   -> Linux
+    New.Android -> Android
+    New.MinGW   -> MinGW
+    New.Win     -> Win
+    New.NetBSD  -> NetBSD
+    New.OpenBSD -> OpenBSD
+
 instance Convertible New.External External where
   convert New.External{..} = External
     (convert eName)
@@ -293,6 +327,7 @@ instance Convertible New.External External where
     (map convert eArgsType)
     eEffectful
     (convert eKind)
+    (convert eLibs)
 
 instance Convertible New.CPat CPat where
   convert = \case

--- a/grin/test/ExtendedSyntax/ParserSpec.hs
+++ b/grin/test/ExtendedSyntax/ParserSpec.hs
@@ -368,6 +368,7 @@ spec = do
                 , eArgsType = [ TySimple T_String ]
                 , eEffectful = True
                 , eKind = PrimOp
+                , eLibs = []
                 }
             , External
                 { eName = "_prim_read_string"
@@ -375,6 +376,7 @@ spec = do
                 , eArgsType = []
                 , eEffectful = True
                 , eKind = PrimOp
+                , eLibs = []
                 }
             , External
                 { eName = "newArrayArray#"
@@ -386,6 +388,7 @@ spec = do
                     ]
                 , eEffectful = True
                 , eKind = PrimOp
+                , eLibs = []
                 }
             , External
                 { eName = "_prim_string_concat"
@@ -396,6 +399,7 @@ spec = do
                     ]
                 , eEffectful = False
                 , eKind = PrimOp
+                , eLibs = []
                 }
             , External
                 { eName = "newArrayArray"
@@ -407,6 +411,7 @@ spec = do
                     ]
                 , eEffectful = False
                 , eKind = FFI
+                , eLibs = []
                 }
             ]
             [ Def "grinMain" [] ( SReturn Unit ) ]
@@ -442,6 +447,7 @@ spec = do
                       ]
                   , eEffectful = False
                   , eKind = PrimOp
+                  , eLibs = []
                   }
               , External
                   { eName = NM { unNM = "_primB" }
@@ -449,6 +455,7 @@ spec = do
                   , eArgsType = [ TySimple T_String ]
                   , eEffectful = False
                   , eKind = PrimOp
+                  , eLibs = []
                   }
               ] []
 

--- a/grin/test/ParserSpec.hs
+++ b/grin/test/ParserSpec.hs
@@ -327,6 +327,12 @@ spec = do
         ffi pure
           newArrayArray :: {Int} -> {State %s} -> {GHC.Prim.Unit {MutableArrayArray %s}}
 
+        ffi effectful
+          linux "libc.so.6"
+          darwin "libc.dylib"
+
+          strcpy :: T_String -> T_String -> T_Unit
+
         grinMain = pure ()
         |]
       let after = Program
@@ -337,6 +343,7 @@ spec = do
                 , eArgsType = [ TySimple T_String ]
                 , eEffectful = True
                 , eKind = PrimOp
+                , eLibs = []
                 }
             , External
                 { eName = "_prim_read_string"
@@ -344,6 +351,7 @@ spec = do
                 , eArgsType = []
                 , eEffectful = True
                 , eKind = PrimOp
+                , eLibs = []
                 }
             , External
                 { eName = "newArrayArray#"
@@ -355,6 +363,7 @@ spec = do
                     ]
                 , eEffectful = True
                 , eKind = PrimOp
+                , eLibs = []
                 }
             , External
                 { eName = "_prim_string_concat"
@@ -365,6 +374,7 @@ spec = do
                     ]
                 , eEffectful = False
                 , eKind = PrimOp
+                , eLibs = []
                 }
             , External
                 { eName = "newArrayArray"
@@ -376,7 +386,18 @@ spec = do
                     ]
                 , eEffectful = False
                 , eKind = FFI
+                , eLibs = []
                 }
+            , External
+                { eName = "strcpy"
+                , eRetType = TySimple T_String
+                , eArgsType =
+                    [ TySimple T_String
+                    , TySimple T_String
+                    ]
+                , eEffectful = True
+                , eKind = FFI
+                , eLibs = [(Linux, "libc.so.6"), (Darwin, "libc.dylib")]}
             ]
             [ Def "grinMain" [] ( SReturn Unit ) ]
       before `sameAs` after
@@ -411,6 +432,7 @@ spec = do
                       ]
                   , eEffectful = False
                   , eKind = PrimOp
+                  , eLibs = []
                   }
               , External
                   { eName = NM { unNM = "_primB" }
@@ -418,6 +440,7 @@ spec = do
                   , eArgsType = [ TySimple T_String ]
                   , eEffectful = False
                   , eKind = PrimOp
+                  , eLibs = []
                   }
               ] []
 

--- a/grin/test/PrettySpec.hs
+++ b/grin/test/PrettySpec.hs
@@ -44,6 +44,7 @@ spec = do
                 , eArgsType = [ TySimple T_String ]
                 , eEffectful = True
                 , eKind = PrimOp
+                , eLibs = []
                 }
             , External
                 { eName = "_prim_read_string"
@@ -51,6 +52,7 @@ spec = do
                 , eArgsType = []
                 , eEffectful = True
                 , eKind = PrimOp
+                , eLibs = []
                 }
             , External
                 { eName = "newArrayArray#"
@@ -62,6 +64,7 @@ spec = do
                     ]
                 , eEffectful = True
                 , eKind = PrimOp
+                , eLibs = []
                 }
             , External
                 { eName = "_prim_string_concat"
@@ -72,6 +75,7 @@ spec = do
                     ]
                 , eEffectful = False
                 , eKind = PrimOp
+                , eLibs = []
                 }
             , External
                 { eName = "newArrayArray"
@@ -83,6 +87,7 @@ spec = do
                     ]
                 , eEffectful = False
                 , eKind = FFI
+                , eLibs = []
                 }
             ]
             [ Def "grinMain" [] ( SReturn Unit ) ]


### PR DESCRIPTION
The syntax is:
```
ffi pure|effectful
    <os> "library"
```
eg
```
ffi pure
    linux "libc.so.6"
    darwin "libc.dylib"

    strcpy :: T_String -> T_String -> T_Unit
```

The interpreter also supports this and now does all ffi function loading at the start, rather than when the function is called.