### PR TITLE
Support ghc 8.10

### DIFF
--- a/grin/cabal.project
+++ b/grin/cabal.project
@@ -1,0 +1,13 @@
+packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/414owen/llvm-hs.git
+    tag: 169e8518b0d9bd425f2daecbcab8b28b54da54dc
+    subdir: llvm-hs
+
+source-repository-package
+    type: git
+    location: https://github.com/414owen/llvm-hs.git
+    tag: 169e8518b0d9bd425f2daecbcab8b28b54da54dc
+    subdir: llvm-hs-pure

--- a/grin/grin.cabal
+++ b/grin/grin.cabal
@@ -244,7 +244,7 @@ library
     optparse-applicative,
     directory,
     pretty-simple,
-    functor-infix,
+    composition-extra,
     generic-random,
     hspec,
     hspec-core,
@@ -299,7 +299,7 @@ test-suite grin-test
   build-depends:       base >=4.11
                      , containers
                      , filepath
-                     , functor-infix
+                     , composition-extra
                      , grin
                      , hspec
                      , hspec-core
@@ -407,7 +407,7 @@ test-suite grin-end-to-end-test
   build-depends:       base >=4.11
                      , containers
                      , filepath
-                     , functor-infix
+                     , composition-extra
                      , grin
                      , hspec
                      , hspec-core

--- a/grin/grin.cabal
+++ b/grin/grin.cabal
@@ -260,7 +260,8 @@ library
     deepseq,
     binary,
     unix,
-    libffi
+    libffi,
+    data-fix
 
   default-language:    Haskell2010
 

--- a/grin/src/AbstractInterpretation/EffectTracking/CodeGenBase.hs
+++ b/grin/src/AbstractInterpretation/EffectTracking/CodeGenBase.hs
@@ -12,7 +12,7 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Vector as Vec
 
-import Data.Functor.Infix
+import Data.Functor.Syntax
 
 import Control.Monad.State
 

--- a/grin/src/AbstractInterpretation/ExtendedSyntax/EffectTracking/CodeGenBase.hs
+++ b/grin/src/AbstractInterpretation/ExtendedSyntax/EffectTracking/CodeGenBase.hs
@@ -12,7 +12,7 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Vector as Vec
 
-import Data.Functor.Infix
+import Data.Functor.Syntax ((<$$>))
 
 import Control.Monad.State
 

--- a/grin/src/Grin/ExtendedSyntax/Lint.hs
+++ b/grin/src/Grin/ExtendedSyntax/Lint.hs
@@ -27,7 +27,7 @@ import Data.String
 import Control.Comonad (extract)
 import qualified Data.Vector as Vector
 import Control.Applicative (liftA2)
-import Data.Functor.Infix ((<$$>))
+import Data.Functor.Syntax ((<$$>))
 
 import Grin.ExtendedSyntax.Grin
 import Grin.ExtendedSyntax.Pretty

--- a/grin/src/Grin/ExtendedSyntax/TypeEnv.hs
+++ b/grin/src/Grin/ExtendedSyntax/TypeEnv.hs
@@ -16,7 +16,6 @@ import qualified Data.Vector as Vector (fromList, toList, map)
 import Data.Bifunctor (bimap)
 import Data.Monoid
 import Data.Maybe (fromMaybe)
-import Data.Functor.Infix ((<$$>))
 import Control.Applicative (liftA2)
 import Control.Monad (join)
 

--- a/grin/src/Grin/Lint.hs
+++ b/grin/src/Grin/Lint.hs
@@ -27,7 +27,7 @@ import Data.String
 import Control.Comonad (extract)
 import qualified Data.Vector as Vector
 import Control.Applicative (liftA2)
-import Data.Functor.Infix ((<$$>))
+import Data.Functor.Syntax ((<$$>))
 
 import Grin.Grin
 import Grin.Pretty

--- a/grin/src/Grin/Research.hs
+++ b/grin/src/Grin/Research.hs
@@ -31,7 +31,7 @@ import qualified Text.PrettyPrint.ANSI.Leijen as Pretty ((<$>))
 import Grin.Pretty (showWide)
 import Control.Arrow ((&&&))
 import Data.Maybe (fromJust)
-import Data.Functor.Infix ((<$$$>))
+import Data.Functor.Syntax ((<$$$>))
 
 
 

--- a/grin/src/Grin/TypeEnv.hs
+++ b/grin/src/Grin/TypeEnv.hs
@@ -16,7 +16,7 @@ import qualified Data.Vector as Vector
 import Data.Bifunctor (bimap)
 import Data.Monoid
 import Data.Maybe (fromMaybe)
-import Data.Functor.Infix ((<$$>))
+import Data.Functor.Syntax ((<$$>))
 import Control.Applicative (liftA2)
 import Control.Monad (join)
 

--- a/grin/src/Lens/Micro/Extra.hs
+++ b/grin/src/Lens/Micro/Extra.hs
@@ -4,7 +4,7 @@ module Lens.Micro.Extra where
 import Lens.Micro.Internal
 import Lens.Micro.Platform
 import Data.Vector as V
-import Data.Functor.Infix ((<$$>))
+import Data.Functor.Syntax ((<$$>))
 import Data.Monoid (Any(..))
 
 

--- a/grin/src/Pipeline/Pipeline.hs
+++ b/grin/src/Pipeline/Pipeline.hs
@@ -118,7 +118,7 @@ import Control.Monad.Extra
 import System.Random
 import Data.Time.Clock
 import Data.Fixed
-import Data.Functor.Infix
+import Data.Functor.Syntax
 import Data.Maybe (isNothing)
 import System.IO (BufferMode(..), hSetBuffering, stdout)
 import Data.Binary as Binary
@@ -344,7 +344,7 @@ data TransformationFunc
 -- TODO: Add n paramter for the transformations that use NameM
 transformationFunc :: Int -> Transformation -> TransformationFunc
 transformationFunc n = \case
-  Vectorisation                   -> WithTypeEnv (newNames <$$> Right <$$> Vectorisation2.vectorisation)
+  Vectorisation                   -> WithTypeEnv (Right . newNames <$$> Vectorisation2.vectorisation)
   GenerateEval                    -> Plain generateEval
   CaseSimplification              -> Plain (noNewNames . caseSimplification)
   SplitFetch                      -> Plain (noNewNames . splitFetch)
@@ -375,7 +375,7 @@ transformationFunc n = \case
   GeneralizedUnboxing             -> WithTypeEnv (Right <$$> generalizedUnboxing)
   ArityRaising                    -> WithTypeEnv (Right <$$> (arityRaising n))
   LateInlining                    -> WithTypeEnv (Right <$$> lateInlining)
-  UnitPropagation                 -> WithTypeEnv (noNewNames <$$> Right <$$> unitPropagation)
+  UnitPropagation                 -> WithTypeEnv (Right . noNewNames <$$> unitPropagation)
   NonSharedElimination            -> WithTypeEnvShr nonSharedElimination
   DeadFunctionElimination         -> WithLVA (noNewNames <$$$$> deadFunctionElimination)
   DeadVariableElimination         -> WithLVA (noNewNames <$$$$> deadVariableElimination)

--- a/grin/src/Reducer/Interpreter/Base.hs
+++ b/grin/src/Reducer/Interpreter/Base.hs
@@ -8,6 +8,7 @@ module Reducer.Interpreter.Base
 
 import Control.Monad.Fail
 import Control.Monad.Trans (MonadIO)
+import Data.Fix (Fix(..))
 import Data.Function (fix)
 import Data.Map.Strict (Map, fromList)
 import Grin.ExtendedSyntax.Syntax hiding (Val)

--- a/grin/src/Reducer/Interpreter/Definitional/Cib.hs
+++ b/grin/src/Reducer/Interpreter/Definitional/Cib.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TypeApplications #-}
 module Reducer.Interpreter.Definitional.Cib where
 
+import Data.Fix (Fix(..))
 import Data.Maybe (mapMaybe)
 import Grin.ExtendedSyntax.Syntax (Name(..))
 import Control.Monad.Fail (MonadFail)
@@ -11,7 +12,6 @@ import Control.Monad.State (gets, modify)
 import Reducer.Interpreter.Base
 import Reducer.Interpreter.Definitional.Internal
 import Reducer.Interpreter.Definitional.Instance
-import Data.Functor.Foldable (Fix)
 import Data.Functor.Sum
 
 import qualified Grin.ExtendedSyntax.Syntax as Syntax

--- a/grin/src/Reducer/Interpreter/Definitional/Instance.hs
+++ b/grin/src/Reducer/Interpreter/Definitional/Instance.hs
@@ -11,6 +11,7 @@ import Control.Monad.Reader (MonadReader(..))
 import Control.Monad.State (MonadState(..))
 import Control.Monad.Trans (MonadIO, lift)
 import Control.Monad.Trans.State hiding (state, get)
+import Data.Fix (Fix(..))
 import Data.Functor.Foldable
 import Data.Functor.Sum
 import Data.Maybe (fromJust)

--- a/grin/src/Reducer/Interpreter/Definitional/Internal.hs
+++ b/grin/src/Reducer/Interpreter/Definitional/Internal.hs
@@ -10,6 +10,7 @@ import Control.Monad.Trans (MonadIO)
 import Control.Monad.Trans.Reader hiding (ask, local)
 import Control.Monad.Trans.State hiding (state, get)
 import Data.Either (fromLeft)
+import Data.Fix (Fix)
 import Data.Functor.Foldable
 import Data.Functor.Sum
 import Data.Int

--- a/grin/src/Reducer/LLVM/CodeGen.hs
+++ b/grin/src/Reducer/LLVM/CodeGen.hs
@@ -434,7 +434,7 @@ codeGenCase opVal alts bindingGen = do
         (Alt DefaultPat _, _) -> True
         _ -> False
       (defaultAlts, normalAlts) = List.partition isDefault alts
-  when (length defaultAlts > 1) $ fail "multiple default patterns"
+  when (length defaultAlts > 1) $ error "multiple default patterns"
   let orderedAlts = defaultAlts ++ normalAlts
 
   (altDests, altValues, altCGTypes) <- fmap List.unzip3 . forM orderedAlts $ \(Alt cpat _, altBody) -> do

--- a/grin/src/Reducer/PrimOps.hs
+++ b/grin/src/Reducer/PrimOps.hs
@@ -19,7 +19,7 @@ import Data.Char (chr, ord)
 import Grin.Grin
 import Data.Map.Strict as Map
 import Data.String (fromString)
-import Data.Functor.Infix ((<$$>))
+import Data.Functor.Syntax ((<$$>))
 import Data.Text as Text
 import Control.Monad.IO.Class
 

--- a/grin/src/Test/ExtendedSyntax/Old/Test.hs
+++ b/grin/src/Test/ExtendedSyntax/Old/Test.hs
@@ -16,7 +16,7 @@ import Control.Monad.Trans.Reader
 import qualified Control.Monad.State.Class as CMS
 import qualified Control.Monad.Reader.Class as CMR
 import Data.Bifunctor
-import Data.Functor.Infix
+import Data.Functor.Syntax
 import Data.Functor.Foldable
 import Data.List ((\\))
 import Data.Maybe (fromJust, maybeToList)

--- a/grin/src/Test/Test.hs
+++ b/grin/src/Test/Test.hs
@@ -16,7 +16,7 @@ import Control.Monad.Trans.Reader
 import qualified Control.Monad.State.Class as CMS
 import qualified Control.Monad.Reader.Class as CMR
 import Data.Bifunctor
-import Data.Functor.Infix
+import Data.Functor.Syntax
 import Data.Functor.Foldable
 import Data.List ((\\))
 import Data.Maybe (fromJust, maybeToList)

--- a/grin/src/Transformations/Optimising/GeneralizedUnboxing.hs
+++ b/grin/src/Transformations/Optimising/GeneralizedUnboxing.hs
@@ -10,7 +10,7 @@ import Data.Maybe
 import Data.List
 import Data.Function
 import Data.Functor.Foldable as Foldable
-import Data.Functor.Infix
+import Data.Functor.Syntax
 import Data.Vector (Vector)
 import qualified Data.Vector as Vector
 import Control.Applicative

--- a/grin/src/Transformations/Simplifying/RegisterIntroduction.hs
+++ b/grin/src/Transformations/Simplifying/RegisterIntroduction.hs
@@ -10,7 +10,7 @@ import qualified Data.Map as Map
 import qualified Data.List as List
 import Data.Functor.Foldable as Foldable
 import qualified Data.Foldable
-import Data.Functor.Infix
+import Data.Functor.Syntax
 import Control.Monad.State
 import Test.Hspec
 

--- a/grin/test/PipelineSpec.hs
+++ b/grin/test/PipelineSpec.hs
@@ -1,6 +1,6 @@
 module PipelineSpec where
 
-import Data.Functor.Infix ((<$$>))
+import Data.Functor.Syntax ((<$$>))
 import Data.List ((\\), nub)
 import Test.Hspec
 import Test.QuickCheck

--- a/grin/test/Reducer/Interpreter/Definitional/CibSpec.hs
+++ b/grin/test/Reducer/Interpreter/Definitional/CibSpec.hs
@@ -1,5 +1,6 @@
 module Reducer.Interpreter.Definitional.CibSpec where
 
+import Data.Fix (Fix(..))
 import Data.Monoid
 import Control.Exception
 import Test.Hspec


### PR DESCRIPTION
Motivation for this change:

Well I ran `nix-shell shell.nix` over an hour ago and it still hasn't finished...

With this change, all you need to run to get a working environment is `nix-shell -p llvmPackages_7.llvm pkg-config libffi`, and your binary caches will work their magic.

I had to make some changes to `llvm-hs`, I'll try upstreaming them.

Some end-to-end tests are failing because of missing `*.binary` files. Not sure what the deal is. I'll see if the CI has more luck.